### PR TITLE
force cice to use box rearranger due to bug in pio255

### DIFF
--- a/machines/config_pio.xml
+++ b/machines/config_pio.xml
@@ -54,6 +54,11 @@
       <value compset="DATM">1</value>
     </values>
   </entry>
+  <entry id="PIO_REARRANGER_ICE">
+    <values>
+      <value compset="CICE">1</value>
+    </values>
+  </entry>
 
   <!--- uncomment and fill in relevant sections
   <entry id="PIO_DEBUG_LEVEL">


### PR DESCRIPTION
Force cice to use PIO_REARRANGER=1