### PR TITLE
Update version of nvhpc for cheyenne

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -696,7 +696,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">pgi/20.4</command>
       </modules>
       <modules compiler="nvhpc">
-        <command name="load">nvhpc/21.11</command>
+        <command name="load">nvhpc/22.2</command>
       </modules>
       <modules compiler="intel" mpilib="!mpi-serial" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/intel/19.1.1/</command>


### PR DESCRIPTION
Update version of nvhpc to 22.2 on cheyenne.  Needed to do this to use pio/2_5_6 module.
