### PR TITLE
Update ESMF lib built by NVHPC/22.2

### DIFF
--- a/machines/Depends.pgi-gpu
+++ b/machines/Depends.pgi-gpu
@@ -1,10 +1,10 @@
 #
 PUMAS_MG_OBJS=\
 micro_mg1_0.o \
-micro_mg3_0.o \
+micro_pumas_v1.o \
 micro_pumas_data.o \
 micro_pumas_utils.o \
-micro_mg_cam.o \
+micro_pumas_cam.o \
 wv_sat_methods.o \
 wv_saturation.o \
 macrop_driver.o \

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -406,22 +406,14 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">pgi/20.4</command>
       </modules>
       <modules compiler="nvhpc">
-        <command name="load">nvhpc/21.11</command>
+        <command name="load">nvhpc/22.1</command>
       </modules>
       <modules compiler="nvhpc-gpu">
-        <command name="load">nvhpc/21.11</command>
+        <command name="load">nvhpc/22.1</command>
       </modules>
       <modules compiler="intel">
         <command name="load">intel/19.1.1</command>
         <command name="load">mkl/2020.0.1</command>
-      </modules>
-      <modules compiler="pgi" mpilib="openmpi" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.2.0b11_casper-ncdfio-openmpi-g</command>
-      </modules>
-      <modules compiler="pgi" mpilib="openmpi" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
-        <command name="load">esmf-8.2.0b11_casper-ncdfio-openmpi-O</command>
       </modules>
       <modules mpilib="openmpi" compiler="pgi">
         <command name="load">openmpi/4.1.0</command>
@@ -481,6 +473,14 @@ This allows using a different mpirun command to launch unit tests
       <modules compiler="nvhpc-gpu" mpilib="openmpi" DEBUG="FALSE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/nvhpc/21.11/</command>
         <command name="load">esmf-8.3.0b06_casper-ncdfio-openmpi-O</command>
+      </modules>
+      <modules compiler="pgi" mpilib="openmpi" DEBUG="TRUE">
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.2.0b11_casper-ncdfio-openmpi-g</command>
+      </modules>
+      <modules compiler="pgi" mpilib="openmpi" DEBUG="FALSE">
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>
+        <command name="load">esmf-8.2.0b11_casper-ncdfio-openmpi-O</command>
       </modules>
       <modules>
         <command name="load">ncarcompilers/0.5.0</command>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -406,10 +406,10 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">pgi/20.4</command>
       </modules>
       <modules compiler="nvhpc">
-        <command name="load">nvhpc/22.1</command>
+        <command name="load">nvhpc/22.2</command>
       </modules>
       <modules compiler="nvhpc-gpu">
-        <command name="load">nvhpc/22.1</command>
+        <command name="load">nvhpc/22.2</command>
       </modules>
       <modules compiler="intel">
         <command name="load">intel/19.1.1</command>
@@ -467,12 +467,12 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">esmf-8.3.0b06_casper-ncdfio-openmpi-O</command>
       </modules>
       <modules compiler="nvhpc-gpu" mpilib="openmpi" DEBUG="TRUE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/nvhpc/21.11/</command>
-        <command name="load">esmf-8.3.0b06_casper-ncdfio-openmpi-g</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/nvhpc/22.2/</command>
+        <command name="load">esmf-8.3.0b09_casper-ncdfio-openmpi-g</command>
       </modules>
       <modules compiler="nvhpc-gpu" mpilib="openmpi" DEBUG="FALSE">
-        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/nvhpc/21.11/</command>
-        <command name="load">esmf-8.3.0b06_casper-ncdfio-openmpi-O</command>
+        <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/nvhpc/22.2/</command>
+        <command name="load">esmf-8.3.0b09_casper-ncdfio-openmpi-O</command>
       </modules>
       <modules compiler="pgi" mpilib="openmpi" DEBUG="TRUE">
         <command name="use">/glade/p/cesmdata/cseg/PROGS/modulefiles/esmfpkgs/pgi/20.4/</command>


### PR DESCRIPTION
There is an AVX link issue between the old NVHPC compiler and OpenMPI lib, which will cause a runtime error when using the ESMF lib in the NUOPC driver.

After upgrading NVHPC to NVHPC/22.2 and re-building the ESMF lib on Casper, the runtime error is gone.

Also change the PUMAS file names in the Depends file for PGI compiler.

This PR fixes this issue https://github.com/ESMCI/ccs_config_cesm/issues/11.

Code review: @jedwards4b 