### PR TITLE
Initial AWS HPC6a config

### DIFF
--- a/machines/cmake_macros/intel_aws-hpc6a.cmake
+++ b/machines/cmake_macros/intel_aws-hpc6a.cmake
@@ -1,0 +1,8 @@
+string(APPEND CFLAGS " -qopt-report -march=core-avx2 -mtune=core-avx2 -no-fma")
+string(APPEND FFLAGS " -qopt-report -march=core-avx2 -mtune=core-avx2 -no-fma")
+if (DEBUG)
+  string(APPEND CMAKE_OPTS " -DPIO_ENABLE_LOGGING=ON")
+endif()
+set(SLIBS "-lnetcdf -lnetcdff -lpnetcdf -lblas -llapack -lpthread -lm -ldl")
+string(APPEND CPPDEFS " -DNO_SHR_VMATH")
+

--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -53,6 +53,17 @@
     </directives>
   </batch_system>
 
+  <batch_system MACH="aws-hpc6a" type="slurm">
+    <batch_submit>sbatch</batch_submit>
+    <submit_args>
+      <arg flag="--time" name="$JOB_WALLCLOCK_TIME"/>
+      <arg flag="-p" name="$JOB_QUEUE"/>
+    </submit_args>
+    <queues>
+      <queue walltimemax="144:00:00" nodemin="1" nodemax="96">regular</queue>
+    </queues>
+  </batch_system>
+
   <batch_system type="cobalt" >
     <batch_query>qstat</batch_query>
     <batch_submit>qsub</batch_submit>

--- a/machines/config_compilers.xml
+++ b/machines/config_compilers.xml
@@ -736,6 +736,31 @@ using a fortran linker.
   <TRILINOS_PATH MPILIB="mpich2">$ENV{TRILINOS_PATH}</TRILINOS_PATH>
 </compiler>
 
+<compiler MACH="aws-hpc6a" COMPILER="intel">
+  <CFLAGS>
+    <append> -qopt-report -march=core-avx2 -mtune=core-avx2 -no-fma</append>
+  </CFLAGS>
+  <FFLAGS>
+    <append> -qopt-report -march=core-avx2 -mtune=core-avx2  -no-fma</append>
+  </FFLAGS>
+  <CMAKE_OPTS>
+    <append DEBUG="TRUE"> -DPIO_ENABLE_LOGGING=ON </append>
+  </CMAKE_OPTS>
+  <FFLAGS>
+    <append MODEL="mom"> -r8 </append>
+  </FFLAGS>
+  <CPPDEFS>
+    <!-- these flags enable nano timers -->
+    <append MODEL="gptl"> -DHAVE_NANOTIME -DBIT64 -DHAVE_VPRINTF -DHAVE_BACKTRACE -DHAVE_SLASHPROC -DHAVE_COMM_F2C -DHAVE_TIMES -DHAVE_GETTIMEOFDAY </append>
+    <append> -DNO_SHR_VMATH</append>
+  </CPPDEFS>
+  <NETCDF_PATH>/opt/ncar/software</NETCDF_PATH>
+  <PNETCDF_PATH>/opt/ncar/software</PNETCDF_PATH>
+  <SLIBS>
+    <base> -lnetcdf -lnetcdff -lpnetcdf -lblas -llapack -lpthread -lm -ldl </base>
+  </SLIBS>
+</compiler>
+
 <compiler MACH="bluewaters">
   <CPPDEFS>
     <append MODEL="gptl"> -DHAVE_PAPI </append>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -200,6 +200,49 @@ This allows using a different mpirun command to launch unit tests
     </environment_variables>
   </machine>
 
+  <machine MACH="aws-hpc6a">
+    <DESC>AWS HPC6a (96-core AMD) Nodes</DESC>
+    <NODENAME_REGEX>regular-dy-computehpc6a-.*</NODENAME_REGEX>
+    <OS>LINUX</OS>
+    <COMPILERS>intel</COMPILERS>
+    <MPILIBS>impi</MPILIBS>
+    <CIME_OUTPUT_ROOT>/scratch/$USER</CIME_OUTPUT_ROOT>
+    <DIN_LOC_ROOT>/scratch/$USER/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT_CLMFORC>/scratch/$USER/inputdata/tss/CTSM_datm_forcing_data</DIN_LOC_ROOT_CLMFORC>
+    <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
+    <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
+    <CCSM_CPRNC>$ENV{CESMDATAROOT}/tools/cime/tools/cprnc/cprnc</CCSM_CPRNC>
+    <GMAKE_J>6</GMAKE_J>
+    <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
+    <SUPPORTED_BY>cseg</SUPPORTED_BY>
+    <!-- have not seen any performance benefit in smt -->
+    <MAX_TASKS_PER_NODE>96</MAX_TASKS_PER_NODE>
+    <MAX_MPITASKS_PER_NODE>96</MAX_MPITASKS_PER_NODE>
+    <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
+    <mpirun mpilib="default">
+      <executable>srun</executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+        <arg name="bindinfo"> --cpu-bind=verbose </arg>
+        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
+        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
+      </arguments>
+    </mpirun>
+    <module_system type="none"/>
+    <environment_variables>
+      <env name="OMP_STACKSIZE">256M</env>
+      <env name="TMPDIR">/scratch/$USER</env>
+      <env name="I_MPI_CC">icc</env>
+      <env name="I_MPI_CXX">icpc</env>
+      <env name="I_MPI_FC">ifort</env>
+      <env name="I_MPI_F90">ifort</env>
+      <env name="NETCDF_PATH">/opt/ncar/software</env>
+    </environment_variables>
+    <resource_limits>
+      <resource name="RLIMIT_STACK">-1</resource>
+    </resource_limits>
+  </machine>
+
   <machine MACH="bluewaters">
     <DESC>ORNL XE6, os is CNL, 32 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>h2o</NODENAME_REGEX>


### PR DESCRIPTION
This is an initial port to the AWS infrastructure for CESM, and specifically the HPC6a nodes.  