### PR TITLE
Added a single environment variable (ESMFMKFILE) needed for CESM2.3+

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -220,12 +220,9 @@ This allows using a different mpirun command to launch unit tests
     <MAX_MPITASKS_PER_NODE>96</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>srun</executable>
+      <executable>scontrol show hostnames $SLURM_JOB_NODELIST > hostfile ; mpirun -f hostfile </executable>
       <arguments>
         <arg name="num_tasks">-n {{ total_tasks }}</arg>
-        <arg name="bindinfo"> --cpu-bind=verbose </arg>
-        <arg name="cpu_bind">--cpu_bind=sockets --cpu_bind=verbose</arg>
-        <arg name="kill-on-bad-exit">--kill-on-bad-exit</arg>
       </arguments>
     </mpirun>
     <module_system type="none"/>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -208,7 +208,7 @@ This allows using a different mpirun command to launch unit tests
     <MPILIBS>impi</MPILIBS>
     <CIME_OUTPUT_ROOT>/scratch/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/scratch/$USER/inputdata</DIN_LOC_ROOT>
-    <DIN_LOC_ROOT_CLMFORC>/scratch/$USER/inputdata/tss/CTSM_datm_forcing_data</DIN_LOC_ROOT_CLMFORC>
+    <DIN_LOC_ROOT_CLMFORC>$DIN_LOC_ROOT/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
     <CCSM_CPRNC>$ENV{CESMDATAROOT}/tools/cime/tools/cprnc/cprnc</CCSM_CPRNC>
@@ -237,6 +237,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="I_MPI_FC">ifort</env>
       <env name="I_MPI_F90">ifort</env>
       <env name="NETCDF_PATH">/opt/ncar/software</env>
+      <env name="ESMFMKFILE">/opt/ncar/esmf/lib/esmf.mk</env>
     </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>

--- a/machines/config_pio.xml
+++ b/machines/config_pio.xml
@@ -55,6 +55,13 @@
     </values>
   </entry>
 
+  <entry id="PIO_REARRANGER" mach="aws-hpc6a">
+    <values>
+      <value>1</value> <!-- Until we sort out the PNetCDF issue on AWS, we'll stick with NetCDF, which needs this -->
+    </values>
+  </entry>
+
+
   <!--- uncomment and fill in relevant sections
   <entry id="PIO_DEBUG_LEVEL">
     <values>
@@ -238,6 +245,13 @@
       <value compset="SCAM">netcdf</value>
     </values>
   </entry>
+
+  <entry id="PIO_TYPENAME" mach="aws-hpc6a">
+    <values>
+      <value>netcdf</value> <!-- Until we sort out the PNetCDF issue on AWS, we'll stick with NetCDF -->
+    </values>
+  </entry>
+
 <!--
   <entry id="ATM_PIO_TYPENAME">
     <values>


### PR DESCRIPTION
This PR just adds a single environment variable (ESMFMKFILE) to the 'aws-hpc6a' config.