### PR TITLE
Additional AWS changes 

### DIFF
--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -61,6 +61,8 @@
     </submit_args>
     <queues>
       <queue walltimemax="144:00:00" nodemin="1" nodemax="96">regular</queue>
+      <queue walltimemax="1:00:00"   nodemin="1" nodemax="1">build</queue>
+      <queue default="true" walltimemax="4:00:00"   jobmin="1" jobmax="1">serial</queue>
     </queues>
   </batch_system>
 

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -207,7 +207,7 @@ This allows using a different mpirun command to launch unit tests
     <COMPILERS>intel</COMPILERS>
     <MPILIBS>impi</MPILIBS>
     <CIME_OUTPUT_ROOT>/scratch/$USER</CIME_OUTPUT_ROOT>
-    <DIN_LOC_ROOT>/scratch/$USER/inputdata</DIN_LOC_ROOT>
+    <DIN_LOC_ROOT>/scratch/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$DIN_LOC_ROOT/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
@@ -217,10 +217,17 @@ This allows using a different mpirun command to launch unit tests
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <!-- have not seen any performance benefit in smt -->
     <MAX_TASKS_PER_NODE>96</MAX_TASKS_PER_NODE>
+    <MAX_GPUS_PER_NODE>1</MAX_GPUS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>96</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>scontrol show hostnames $SLURM_JOB_NODELIST > hostfile ; mpirun -f hostfile </executable>
+      <arguments>
+        <arg name="num_tasks">-n {{ total_tasks }}</arg>
+      </arguments>
+    </mpirun>
+    <mpirun mpilib="default" queue="serial">
+      <executable>env -u I_MPI_OFI_PROVIDER mpirun </executable>
       <arguments>
         <arg name="num_tasks">-n {{ total_tasks }}</arg>
       </arguments>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -217,7 +217,6 @@ This allows using a different mpirun command to launch unit tests
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <!-- have not seen any performance benefit in smt -->
     <MAX_TASKS_PER_NODE>96</MAX_TASKS_PER_NODE>
-    <MAX_GPUS_PER_NODE>1</MAX_GPUS_PER_NODE>
     <MAX_MPITASKS_PER_NODE>96</MAX_MPITASKS_PER_NODE>
     <PROJECT_REQUIRED>FALSE</PROJECT_REQUIRED>
     <mpirun mpilib="default">

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -212,7 +212,7 @@ This allows using a different mpirun command to launch unit tests
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
     <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
     <CCSM_CPRNC>$ENV{CESMDATAROOT}/tools/cime/tools/cprnc/cprnc</CCSM_CPRNC>
-    <GMAKE_J>6</GMAKE_J>
+    <GMAKE_J>8</GMAKE_J>
     <BATCH_SYSTEM>slurm</BATCH_SYSTEM>
     <SUPPORTED_BY>cseg</SUPPORTED_BY>
     <!-- have not seen any performance benefit in smt -->


### PR DESCRIPTION

This PR changes several more things related to the AWS environment.  It:

1) Adds additional queues (for compiling and serial runs, both of which keep costs down)
2) Makes the inputdata be a central location, vs a user-specific one (on the system, we use a sticky bit with group permissions so anyone in the group can write to it, but not overwrite other files -- in short, multiple people can download input data)
3) Changes GMAKE_J to 8 to take advantage of the 8-core build queue
4) Sets MAX_GPUS_PER_NODE to 1, even though we aren't using GPUs, as a way of silencing a warning during 'run_neon'.
5) Configures launching in the serial queue via the unsetting of an environment variable that's necessary for good performance on AWS's HPC nodes, but crashes MPI on nodes without EFA (Elastic Fabric Adapter).