### PR TITLE
Add ESMF env for Casper to output timing file correctly

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -546,6 +546,10 @@ This allows using a different mpirun command to launch unit tests
       <env name="CESMDATAROOT">/glade/p/cesmdata/cseg</env>
       <env name="NETCDF_PATH">$ENV{NETCDF}</env>
     </environment_variables>
+    <environment_variables comp_interface="nuopc">
+      <env name="ESMF_RUNTIME_PROFILE">ON</env>
+      <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+    </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>


### PR DESCRIPTION
This PR fixes an issue on Casper that fails to output the timing summary file when using the NUOPC driver.

Following @jedwards4b's suggestions, two environment variables are added. 