### PR TITLE
Added ESMF variables for timing output on AWS, per Jian's PR

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -242,6 +242,10 @@ This allows using a different mpirun command to launch unit tests
       <env name="NETCDF_PATH">/opt/ncar/software</env>
       <env name="ESMFMKFILE">/opt/ncar/esmf/lib/esmf.mk</env>
     </environment_variables>
+     <environment_variables comp_interface="nuopc">
+       <env name="ESMF_RUNTIME_PROFILE">ON</env>
+       <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
+    </environment_variables>
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>


### PR DESCRIPTION

This just adds the same environment variables Jian added for Casper for AWS., for getting timing output from NUOPC runs.