### PR TITLE
Fix path to CIME tools

### DIFF
--- a/machines/template.case.run
+++ b/machines/template.case.run
@@ -13,7 +13,7 @@ DO NOT RUN THIS SCRIPT MANUALLY
 import os, sys
 os.chdir( '{{ caseroot }}')
 
-_LIBDIR = os.path.join("{{ cimeroot }}", "scripts", "Tools")
+_LIBDIR = os.path.join("{{ cimeroot }}", "CIME", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup          import *

--- a/machines/template.case.test
+++ b/machines/template.case.test
@@ -10,7 +10,7 @@ DO NOT RUN THIS SCRIPT MANUALLY
 import os, sys
 os.chdir( '{{ caseroot }}')
 
-_LIBDIR = os.path.join("{{ cimeroot }}", "scripts", "Tools")
+_LIBDIR = os.path.join("{{ cimeroot }}", "CIME", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup import *

--- a/machines/template.st_archive
+++ b/machines/template.st_archive
@@ -12,7 +12,7 @@ is called by case.submit on batch systems.
 import sys, os, time
 os.chdir( '{{ caseroot }}')
 
-_LIBDIR = os.path.join("{{ cimeroot }}", "scripts", "Tools")
+_LIBDIR = os.path.join("{{ cimeroot }}", "CIME", "Tools")
 sys.path.append(_LIBDIR)
 
 from standard_script_setup          import *


### PR DESCRIPTION
Fixes #45 . See description there for details.

Testing: ran the following tests from CTSM master with ccs_config updated to this branch:
- SMS_D_Ld1.f10_f10_mg37.I1850Clm50BgcCrop.cheyenne_gnu.clm-default (run via create_test)
- SMS_Ld5_D_P48x1.f10_f10_mg37.IHistClm51Bgc.izumi_nag.clm-decStart (run via run_sys_tests)