### PR TITLE
Add pnetcdf module for gnu/openmpi on cheyenne

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -889,6 +889,7 @@ This allows using a different mpirun command to launch unit tests
       <modules mpilib="openmpi" compiler="gnu">
         <command name="load">openmpi/4.1.4</command>
         <command name="load">netcdf-mpi/4.9.0</command>
+        <command name="load">pnetcdf/1.12.3</command>
       </modules>
       <modules>
         <command name="load">ncarcompilers/0.5.0</command>


### PR DESCRIPTION
Add pnetcdf module load for gnu/openmpi on cheyenne.
Fixes #57