### PR TITLE
make 4x5 mesh cdf5

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -53,7 +53,7 @@
     <nx>72</nx> <ny>46</ny>
     <!-- This is needed for PTS_MODE - it specifies the xml variable PTS_DOMAINFILE -->
     <file>$DIN_LOC_ROOT/share/domains/domain.lnd.fv4x5_gx3v7.091218.nc</file>
-    <mesh>$DIN_LOC_ROOT/share/meshes/fv4x5_050615_polemod_ESMFmesh.nc</mesh>
+    <mesh>$DIN_LOC_ROOT/share/meshes/fv4x5_050615_polemod_ESMFmesh_cdf5.nc</mesh>
     <desc>4x5 is FV 4-deg grid:</desc>
   </domain>
   <domain name="10x15">
@@ -401,7 +401,7 @@
   <domain name="r05mz_amazon">
     <nx>816</nx> <ny>1</ny>
     <mesh>$DIN_LOC_ROOT/rof/mizuRoute/meshes/r05_amazon_c110308_ctrcrd_cdf5_ESMFmesh_c20200624.nc</mesh>
-    <desc>r05_amazon is the regular 1/2 degree river routing grid, but over a region in the Amazon 
+    <desc>r05_amazon is the regular 1/2 degree river routing grid, but over a region in the Amazon
     (corresponds to the 5x5_amazon region for CTSM) </desc>
   </domain>
   <domain name="HDMAmz">


### PR DESCRIPTION
The  fv4x5_050615_polemod_ESMFmesh.nc on cheyenne was cdf5 but in the subversion data server it was not.
So trying to use it on other machines failed. A new file fv4x5_050615_polemod_ESMFmesh_cdf5.nc has been created on both cheyenne and imported to the data servers. This PR now references the new file.