### PR TITLE
update izumi modules replace pgi with nvhpc

### DIFF
--- a/machines/cmake_macros/izumi.cmake
+++ b/machines/cmake_macros/izumi.cmake
@@ -5,5 +5,10 @@ set(LAPACK_LIBDIR "/usr/lib64")
 if (MPILIB STREQUAL mvapich2)
   set(MPI_LIB_NAME "mpich")
 endif()
-set(NETCDF_PATH "$ENV{NETCDF_PATH}")
-string(APPEND SLIBS " -L${NETCDF_PATH}/lib -lnetcdff -lnetcdf")
+# These should not be evaluated until build time
+
+string(APPEND LDFLAGS " -Wl,-rpath,\$(PARALLELIO_PATH)/lib")
+string(APPEND LDFLAGS " -Wl,-rpath,\$(NETCDF_PATH)/lib")
+
+set(NETCDF_PATH "\$ENV{NETCDF_PATH}")
+string(APPEND SLIBS "  -lnetcdff -lnetcdf")

--- a/machines/cmake_macros/izumi.cmake
+++ b/machines/cmake_macros/izumi.cmake
@@ -9,6 +9,4 @@ endif()
 
 string(APPEND LDFLAGS " -Wl,-rpath,\$(PARALLELIO_PATH)/lib")
 string(APPEND LDFLAGS " -Wl,-rpath,\$(NETCDF_PATH)/lib")
-
-set(NETCDF_PATH "\$ENV{NETCDF_PATH}")
 string(APPEND SLIBS "  -lnetcdff -lnetcdf")

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -2121,6 +2121,8 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules compiler="gnu">
         <command name="load">compiler/gnu/9.3.0</command>
+	<command name="unload">tool/hdf5</command>
+	<command name="unload">tool/netcdf</command>
 	<command name="load">/fs/cgd/data0/modules/modulefiles/gcc/9.3.0/netcdf/4.9.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mpi-serial">
@@ -2135,9 +2137,11 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules compiler="nvhpc">
         <command name="load">compiler/nvhpc/22.11</command>
+	<command name="load">tool/netcdf/4.9.0/hpc-sdk</command>
       </modules>
       <modules compiler="nvhpc" mpilib="mpi-serial">
 	<command name="use">/fs/cgd/data0/modules/modulefiles/nvhpc/22.11</command>
+	
       </modules>
 
       <modules compiler="nvhpc" mpilib="openmpi">
@@ -2146,6 +2150,8 @@ This allows using a different mpirun command to launch unit tests
 
       <modules compiler="intel">
         <command name="load">compiler/intel/20.0.1</command>
+	<command name="unload">tool/hdf5</command>
+	<command name="unload">tool/netcdf</command>
 	<command name="load">/fs/cgd/data0/modules/modulefiles/intel/20.0.1/netcdf/4.9.0</command>
       </modules>
       <modules compiler="intel" mpilib="mpi-serial">
@@ -2155,12 +2161,10 @@ This allows using a different mpirun command to launch unit tests
         <command name="load">mpi/2.3.3/intel/20.0.1</command>
 	<command name="use">/fs/cgd/data0/modules/modulefiles/mvapich2/2.3.3/intel/20.0.1</command>
       </modules>
-      <modules compiler="pgi">
-        <command name="load">compiler/pgi/20.1</command>
-        <command name="load">tool/netcdf/4.7.4/pgi/20.1</command>
-      </modules>
       <modules compiler="nag">
         <command name="load">compiler/nag/6.2-8.1.0</command>
+	<command name="unload">tool/hdf5</command>
+	<command name="unload">tool/netcdf</command>
 	<command name="load">/fs/cgd/data0/modules/modulefiles/nag/7.0/netcdf/4.9.0</command>
       </modules>
       <modules compiler="nag" mpilib="mpi-serial">
@@ -2175,12 +2179,13 @@ This allows using a different mpirun command to launch unit tests
         <command name="unload">openmpi</command>
 	<command name="load">mpi-serial</command>
       </modules>
+
       <modules>
-	<command name="unload">tool/hdf5</command>
-	<command name="unload">tool/netcdf</command>
 	<command name="load">parallelio/2.5.10</command>
 	<command name="load">esmf/8.4.1b02</command>
       </modules>
+
+
     </module_system>
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -2074,8 +2074,11 @@ This allows using a different mpirun command to launch unit tests
     <DESC>NCAR CGD Linux Cluster 48 pes/node, batch system is PBS</DESC>
     <NODENAME_REGEX>^i.*\.ucar\.edu</NODENAME_REGEX>
     <OS>LINUX</OS>
-    <COMPILERS>intel,pgi,nag,gnu</COMPILERS>
-    <MPILIBS>mvapich2,openmpi</MPILIBS>
+    <COMPILERS>intel,nvhpc,nag,gnu</COMPILERS>
+    <MPILIBS compiler="intel">mvapich2</MPILIBS>
+    <MPILIBS compiler="nag">mvapich2</MPILIBS>
+    <MPILIBS compiler="gnu">mvapich2</MPILIBS>
+    <MPILIBS compiler="nvhpc">openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>/scratch/cluster/$USER</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>/fs/cgd/csm/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>/project/tss</DIN_LOC_ROOT_CLMFORC>
@@ -2118,20 +2121,39 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules compiler="gnu">
         <command name="load">compiler/gnu/9.3.0</command>
-        <command name="load">tool/netcdf/4.7.4/gnu/9.3.0</command>
+	<command name="load">/fs/cgd/data0/modules/modulefiles/gcc/9.3.0/netcdf/4.9.0</command>
+      </modules>
+      <modules compiler="gnu" mpilib="mpi-serial">
+	<command name="use">/fs/cgd/data0/modules/modulefiles/gcc/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="openmpi">
         <command name="load">openmpi/4.0.3/gnu/9.3.0</command>
       </modules>
       <modules compiler="gnu" mpilib="mvapich2">
         <command name="load">mpi/2.3.3/gnu/9.3.0</command>
+	<command name="use">/fs/cgd/data0/modules/modulefiles/mvapich2/2.3.3/gcc/9.3.0</command>
       </modules>
+      <modules compiler="nvhpc">
+        <command name="load">compiler/nvhpc/22.11</command>
+      </modules>
+      <modules compiler="nvhpc" mpilib="mpi-serial">
+	<command name="use">/fs/cgd/data0/modules/modulefiles/nvhpc/22.11</command>
+      </modules>
+
+      <modules compiler="nvhpc" mpilib="openmpi">
+	<command name="use">/fs/cgd/data0/modules/modulefiles/openmpi/3.1.5/nvhpc/22.11</command>
+      </modules>
+
       <modules compiler="intel">
         <command name="load">compiler/intel/20.0.1</command>
-        <command name="load">tool/netcdf/4.7.4/intel/20.0.1</command>
+	<command name="load">/fs/cgd/data0/modules/modulefiles/intel/20.0.1/netcdf/4.9.0</command>
+      </modules>
+      <modules compiler="intel" mpilib="mpi-serial">
+	<command name="use">/fs/cgd/data0/modules/modulefiles/intel/20.0.1</command>
       </modules>
       <modules compiler="intel" mpilib="mvapich2">
         <command name="load">mpi/2.3.3/intel/20.0.1</command>
+	<command name="use">/fs/cgd/data0/modules/modulefiles/mvapich2/2.3.3/intel/20.0.1</command>
       </modules>
       <modules compiler="pgi">
         <command name="load">compiler/pgi/20.1</command>
@@ -2139,78 +2161,25 @@ This allows using a different mpirun command to launch unit tests
       </modules>
       <modules compiler="nag">
         <command name="load">compiler/nag/6.2-8.1.0</command>
-        <command name="load">tool/netcdf/c4.6.1-f4.4.4/nag-gnu/6.2-8.1.0</command>
+	<command name="load">/fs/cgd/data0/modules/modulefiles/nag/7.0/netcdf/4.9.0</command>
+      </modules>
+      <modules compiler="nag" mpilib="mpi-serial">
+	<command name="use">/fs/cgd/data0/modules/modulefiles/nag/7.0</command>
       </modules>
       <modules compiler="nag" mpilib="mvapich2">
         <command name="load">mpi/2.3.3/nag/6.2</command>
+	<command name="use">/fs/cgd/data0/modules/modulefiles/mvapich2/2.3.3/nag/7.0</command>
       </modules>
-      <modules compiler="nag" mpilib="mpi-serial">
-        <command name="rm">mpi</command>
+      <modules mpilib="mpi-serial">
+        <command name="unload">mpi</command>
+        <command name="unload">openmpi</command>
+	<command name="load">mpi-serial</command>
       </modules>
-      <modules compiler="gnu" mpilib="mvapich2" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/gfortran/9.3.0</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-O</command>
-      </modules>
-      <modules compiler="gnu" mpilib="mvapich2" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/gfortran/9.3.0</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-g</command>
-      </modules>
-      <modules compiler="gnu" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/gfortran/9.3.0</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-O</command>
-      </modules>
-      <modules compiler="gnu" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/gfortran/9.3.0</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-g</command>
-      </modules>
-
-      <modules compiler="nag" mpilib="mvapich2" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/nag/6.2</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-O</command>
-      </modules>
-      <modules compiler="nag" mpilib="mvapich2" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/nag/6.2</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-g</command>
-      </modules>
-      <modules compiler="nag" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/nag/6.2</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-g</command>
-      </modules>
-      <modules compiler="nag" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/nag/6.2</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-O</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/intel/20.0.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-g</command>
-      </modules>
-      <modules compiler="intel" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/intel/20.0.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-O</command>
-      </modules>
-      <modules compiler="intel" mpilib="mvapich2" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/intel/20.0.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-g</command>
-      </modules>
-      <modules compiler="intel" mpilib="mvapich2" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/intel/20.0.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-O</command>
-      </modules>
-      <modules compiler="pgi" mpilib="mpi-serial" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/pgi/20.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-g</command>
-      </modules>
-      <modules compiler="pgi" mpilib="mpi-serial" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/pgi/20.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mpiuni-O</command>
-      </modules>
-      <modules compiler="pgi" mpilib="mvapich2" DEBUG="TRUE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/pgi/20.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-g</command>
-      </modules>
-      <modules compiler="pgi" mpilib="mvapich2" DEBUG="FALSE">
-        <command name="use">/fs/cgd/data0/modules/modulefiles/esmfpkgs/pgi/20.1</command>
-        <command name="load">esmf-8.2.0-ncdfio-mvapich2-O</command>
+      <modules>
+	<command name="unload">tool/hdf5</command>
+	<command name="unload">tool/netcdf</command>
+	<command name="load">parallelio/2.5.10</command>
+	<command name="load">esmf/8.4.1b02</command>
       </modules>
     </module_system>
     <environment_variables>
@@ -2218,9 +2187,7 @@ This allows using a different mpirun command to launch unit tests
       <!-- The following is needed in order to run qsub from the compute nodes -->
       <env name="PATH">$ENV{PATH}:/cluster/torque/bin</env>
     </environment_variables>
-    <environment_variables compiler="intel">
-      <env name="PIO">/home/jedwards/pio/2.5.7/intel</env>
-    </environment_variables>
+
     <resource_limits>
       <resource name="RLIMIT_STACK">-1</resource>
     </resource_limits>


### PR DESCRIPTION
Remove pgi compiler, add nvhpc compiler.  Add parallelio, mpi-serial and esmf modules.  