### PR TITLE
update CMake module for Cheyenne

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -644,7 +644,7 @@ This allows using a different mpirun command to launch unit tests
         <command name="purge"/>
         <command name="load">ncarenv/1.3</command>
         <command name="load">python/3.7.9</command>
-        <command name="load">cmake/3.18.2</command>
+        <command name="load">cmake/3.22.0</command>
       </modules>
       <modules compiler="intel">
         <command name="load">intel/19.1.1</command>


### PR DESCRIPTION
This PR updates the version of CMake used on Cheyenne to 3.22.0. The newer version is needed for [CAM PR 784](https://github.com/ESCOMP/CAM/pull/784)

(This is my first PR on this repo, so apologies if this is not the correct way to make this change)