### PR TITLE
update esmf lib for pleiades

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -2818,7 +2818,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="MPI_TYPE_DEPTH">16</env>
       <env name="OMP_STACKSIZE">256M</env>
-      <env name="ESMFMKFILE">/home6/fvitt/esmf-8_2_0/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/home6/fvitt/ESMFv8.4.1/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
   </machine>
 
@@ -2872,7 +2872,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="MPI_TYPE_DEPTH">16</env>
       <env name="OMP_STACKSIZE">256M</env>
-      <env name="ESMFMKFILE">/home6/fvitt/esmf-8_2_0/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/home6/fvitt/ESMFv8.4.1/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
   </machine>
 
@@ -2926,7 +2926,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="MPI_TYPE_DEPTH">16</env>
       <env name="OMP_STACKSIZE">256M</env>
-      <env name="ESMFMKFILE">/home6/fvitt/esmf-8_2_0/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/home6/fvitt/ESMFv8.4.1/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
   </machine>
 
@@ -2980,7 +2980,7 @@ This allows using a different mpirun command to launch unit tests
       <env name="MPI_TYPE_MAX">100000</env>
       <env name="MPI_TYPE_DEPTH">16</env>
       <env name="OMP_STACKSIZE">256M</env>
-      <env name="ESMFMKFILE">/home6/fvitt/esmf-8_2_0/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
+      <env name="ESMFMKFILE">/home6/fvitt/ESMFv8.4.1/lib/libO/Linux.intel.64.mpt.default/esmf.mk</env>
     </environment_variables>
   </machine>
 


### PR DESCRIPTION
Update ESMF to version 8.4.1 on pleiades machines

Testing:
 ```
  SMS_D_Ln9_Vnuopc.f19_f19_mg17.FX2000.pleiades-bro_intel.cam-outfrq9s (Overall: PASS) details:
  SMS_D_Ln9_Vnuopc.f19_f19_mg17.FX2000.pleiades-has_intel.cam-outfrq9s (Overall: PASS) details:
  SMS_D_Ln9_Vnuopc.f19_f19_mg17.FX2000.pleiades-ivy_intel.cam-outfrq9s (Overall: PASS) details:
  SMS_D_Ln9_Vnuopc.f19_f19_mg17.FX2000.pleiades-san_intel.cam-outfrq9s (Overall: PASS) details:
  SMS_Ld1.f19_f19_mg17.FX2000.pleiades-bro_intel.cam-outfrq1d (Overall: PASS) details:
  SMS_Ld1.f19_f19_mg17.FX2000.pleiades-ivy_intel.cam-outfrq1d (Overall: PASS) details:
```
