### PR TITLE
Add new MOM6 grid tx2_3v2

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -359,6 +359,12 @@
     <desc>tx0.66v1 is tripole v1 0.66-deg MOM6 grid:</desc>
     <support>Experimental for MOM6 experiments</support>
   </domain>
+  <domain name="tx2_3v2">
+    <nx>540</nx> <ny>480</ny>
+    <mesh>$DIN_LOC_ROOT/share/meshes/tx2_3v2_230415_ESMFmesh.nc</mesh>
+    <desc>tx2_3v2 is tripole v2 2/3-deg MOM6 grid:</desc>
+    <support>Experimental for MOM6 experiments</support>
+  </domain>
   <domain name="tx0.25v1">
     <nx>1440</nx> <ny>1080</ny>
     <mesh>$DIN_LOC_ROOT/share/meshes/tx0.25v1_190204_ESMFmesh.nc</mesh>

--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -82,9 +82,17 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx0.66v1_e1000r300_190314.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx0.66v1_e1000r300_190314.nc</map>
     </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="tx2_3v2" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx2_3_nnsm_e1000r1000_230415.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/r05/map_r05_to_tx2_3_nnsm_e1000r1000_230415.nc</map>
+    </gridmap>
     <gridmap rof_grid="JRA025" ocn_grid="tx0.66v1" >
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_JRA025m_to_tx0.66v1_nnsm_e333r100_190910.nc</map>
+    </gridmap>
+    <gridmap rof_grid="JRA025" ocn_grid="tx2_3v2" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_jra_to_tx2_3_nnsm_e333r100_230415.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_jra_to_tx2_3_nnsm_e333r100_230415.nc</map>
     </gridmap>
 
     <!-- ======================================================== -->
@@ -131,6 +139,10 @@
     <gridmap ocn_grid="tx0.66v1" glc_grid="gris4" >
       <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_tx0.66v1_nnsm_e1000r300_190314.nc</map>
       <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_tx0.66v1_nnsm_e1000r300_190314.nc</map>
+    </gridmap>
+    <gridmap ocn_grid="tx2_3v2" glc_grid="gris4" >
+      <map name="GLC2OCN_LIQ_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_tx2_3_nnsm_e1000r300_230415.nc</map>
+      <map name="GLC2OCN_ICE_RMAPNAME">cpl/gridmaps/gland4km/map_gland4km_to_tx2_3_nnsm_e1000r300_230415.nc</map>
     </gridmap>
 
     <!-- ======================================================== -->

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -349,6 +349,13 @@
     <grid name="rof">JRA025</grid>
   </model_grid>
 
+  <model_grid alias="TL319_t232" compset="DATM%JRA">
+    <grid name="atm">TL319</grid>
+    <grid name="lnd">TL319</grid>
+    <grid name="ocnice">tx2_3v2</grid>
+    <grid name="rof">JRA025</grid>
+  </model_grid>
+
   <model_grid alias="TL319_t061_wt061" not_compset="_CAM">
     <grid name="atm">TL319</grid>
     <grid name="lnd">TL319</grid>
@@ -415,6 +422,12 @@
     <grid name="atm">0.9x1.25</grid>
     <grid name="lnd">0.9x1.25</grid>
     <grid name="ocnice">tx0.66v1</grid>
+  </model_grid>
+
+  <model_grid alias="f09_t232">
+    <grid name="atm">0.9x1.25</grid>
+    <grid name="lnd">0.9x1.25</grid>
+    <grid name="ocnice">tx2_3v2</grid>
   </model_grid>
 
   <model_grid alias="T62_g16" not_compset="_CAM">

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -888,6 +888,13 @@
     <mask>tx0.66v1</mask>
   </model_grid>
 
+  <model_grid alias="ne30pg3_t232">
+    <grid name="atm">ne30np4.pg3</grid>
+    <grid name="lnd">ne30np4.pg3</grid>
+    <grid name="ocnice">tx2_3v2</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="ne30_f19_g16">
     <grid name="atm">ne30np4</grid>
     <grid name="lnd">1.9x2.5</grid>


### PR DESCRIPTION
Add the new MOM6 domain tx2_3v2, as well as resolution definitions and map files. This Pr should be evaluated in conjunction with https://github.com/ESCOMP/MOM_interface/pull/141