### PR TITLE
Derecho updates 071223

### DIFF
--- a/machines/Depends.intel-oneapi
+++ b/machines/Depends.intel-oneapi
@@ -7,10 +7,8 @@ bndry_mod.o \
 prim_advance_mod.o
 
 # CLM's SatellitePhenologyMod is compiled incorrectly with intel 15.0.0 at -O2
-# CAMS unicon.F90 generates an ICE with ifx  2023.0.0 20221201
 REDUCED_OPT_OBJS=\
-SatellitePhenologyMod.o \
-unicon.o
+SatellitePhenologyMod.o 
 
 # shr_wv_sat_mod does not need to have better than ~0.1% precision, and benefits
 # enormously from a lower precision in the vector functions.

--- a/machines/Depends.intel-oneapi
+++ b/machines/Depends.intel-oneapi
@@ -1,0 +1,53 @@
+#
+PERFOBJS=\
+prim_advection_mod.o \
+edge_mod.o \
+derivative_mod.o \
+bndry_mod.o \
+prim_advance_mod.o
+
+# CLM's SatellitePhenologyMod is compiled incorrectly with intel 15.0.0 at -O2
+# CAMS unicon.F90 generates an ICE with ifx  2023.0.0 20221201
+REDUCED_OPT_OBJS=\
+SatellitePhenologyMod.o \
+unicon.o
+
+# shr_wv_sat_mod does not need to have better than ~0.1% precision, and benefits
+# enormously from a lower precision in the vector functions.
+REDUCED_PRECISION_OBJS=\
+shr_wv_sat_mod.o
+
+SHR_RANDNUM_FORT_OBJS=\
+kissvec_mod.o \
+mersennetwister_mod.o \
+dSFMT_interface.o \
+shr_RandNum_mod.o
+
+SHR_RANDNUM_C_OBJS=\
+dSFMT.o \
+dSFMT_utils.o \
+kissvec.o
+
+PUMAS_MG_OBJS=\
+micro_mg1_0.o \
+micro_pumas_v1.o \
+micro_pumas_data.o \
+micro_pumas_utils.o \
+wv_sat_methods.o
+
+
+ifeq ($(DEBUG),FALSE)
+  $(PERFOBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -O3  -no-prec-div $<
+  $(REDUCED_OPT_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS)  -O1 $<
+  $(REDUCED_PRECISION_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fimf-precision=low -fp-model fast $<
+  $(SHR_RANDNUM_FORT_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -fp-model fast -no-prec-div -no-prec-sqrt -qoverride-limits $<
+  $(SHR_RANDNUM_C_OBJS): %.o: %.c
+	  $(CC) -c $(INCLDIR) $(INCS) $(CFLAGS) -O3 -fp-model fast $<
+  $(PUMAS_MG_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -no-fma -ftz -no-prec-sqrt -qoverride-limits -no-inline-max-total-size -inline-factor=200 -qopt-report=5 $<
+
+endif

--- a/machines/cmake_macros/intel-oneapi.cmake
+++ b/machines/cmake_macros/intel-oneapi.cmake
@@ -1,0 +1,1 @@
+intel.cmake

--- a/machines/cmake_macros/intel-oneapi_derecho.cmake
+++ b/machines/cmake_macros/intel-oneapi_derecho.cmake
@@ -1,0 +1,1 @@
+intel_derecho.cmake

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -1382,6 +1382,8 @@ This allows using a different mpirun command to launch unit tests
     <environment_variables>
       <env name="OMP_STACKSIZE">64M</env>
       <env name="FI_CXI_RX_MATCH_MODE">hybrid</env>
+      <!-- https://support.hpe.com/hpesc/public/docDisplay?docId=a00129146en_us&docLocale=en_US -->
+      <env name="FI_MR_CACHE_MONITOR">memhooks</env>
     </environment_variables>
     <!-- derecho has both gpfs and lustre file systems so I think this setting may cause issues -->
     <!--    <environment_variables mpilib="mpich">

--- a/machines/config_pio.xml
+++ b/machines/config_pio.xml
@@ -78,13 +78,14 @@
   </entry>
   -->
 
-  <!--- uncomment and fill in relevant sections
+
   <entry id="PIO_BUFFER_SIZE_LIMIT">
     <values>
-      <value></value>
+      <value compset="CAM%DEV%MT" mach="cheyenne">17108864</value>
     </values>
   </entry>
-  -->
+
+
 
   <!--- uncomment and fill in relevant sections
   <entry id="OCN_PIO_STRIDE">


### PR DESCRIPTION
Replace MPICH_COLL_SYNC=1 with 
FI_MR_CACHE_MONITOR=memhooks.  

See https://support.hpe.com/hpesc/public/docDisplay?docId=a00129146en_us&docLocale=en_US

for details - this new env variable seems to work better than the MPICH_COLL_SYNC.   