### PR TITLE
Change baseline path from ccsm to cesm, and update ESMF of derecho

### DIFF
--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -1370,12 +1370,12 @@ This allows using a different mpirun command to launch unit tests
 
       <modules DEBUG="TRUE">
 	<command name="load">parallelio/2.6.0-debug</command>
-	<command name="load">esmf/8.5.0</command>
+	<command name="load">esmf/8.6.0b03</command>
       </modules>
 
       <modules DEBUG="FALSE">
 	<command name="load">parallelio/2.6.0</command>
-	<command name="load">esmf/8.5.0</command>
+	<command name="load">esmf/8.6.0b03</command>
         </modules>
     </module_system>
 

--- a/machines/config_machines.xml
+++ b/machines/config_machines.xml
@@ -1294,7 +1294,7 @@ This allows using a different mpirun command to launch unit tests
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
     <DIN_LOC_ROOT_CLMFORC>$ENV{CESMDATAROOT}/inputdata/atm/datm7</DIN_LOC_ROOT_CLMFORC>
     <DOUT_S_ROOT>$CIME_OUTPUT_ROOT/archive/$CASE</DOUT_S_ROOT>
-    <BASELINE_ROOT>$ENV{CESMDATAROOT}/ccsm_baselines</BASELINE_ROOT>
+    <BASELINE_ROOT>$ENV{CESMDATAROOT}/cesm_baselines</BASELINE_ROOT>
     <CCSM_CPRNC>$ENV{CESMDATAROOT}/cprnc/cprnc</CCSM_CPRNC>
     <GMAKE_J>16</GMAKE_J>
     <BATCH_SYSTEM>pbs</BATCH_SYSTEM>
@@ -1370,12 +1370,12 @@ This allows using a different mpirun command to launch unit tests
 
       <modules DEBUG="TRUE">
 	<command name="load">parallelio/2.6.0-debug</command>
-	<command name="load">esmf/8.5.0b23-debug</command>
+	<command name="load">esmf/8.5.0</command>
       </modules>
 
       <modules DEBUG="FALSE">
 	<command name="load">parallelio/2.6.0</command>
-	<command name="load">esmf/8.5.0b23</command>
+	<command name="load">esmf/8.5.0</command>
         </modules>
     </module_system>
 


### PR DESCRIPTION
For derecho,
      BASELINE_ROOT was set to ccsm_baselines, it should be cesm_baselines.
      Also update ESMF library to ESMF8.6.0b03.