### PR TITLE
Add "-V" option back to avoid a python issue on Cheyenne

### DIFF
--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -156,6 +156,7 @@
       <directive default="n"> -r {{ rerunnable }} </directive>
       <!-- <directive> -j oe {{ job_id }} </directive> -->
       <directive> -j oe </directive>
+      <directive> -V </directive>
     </directives>
   </batch_system>
 


### PR DESCRIPTION
According to many feedback, removing the `-V` option from PBS resource will lead to an error like below on Cheyenne:

> File "/var/spool/pbs/mom_priv/jobs/[3309939.chadmin1.ib0.cheyenne.ucar.edu.SC](http://3309939.chadmin1.ib0.cheyenne.ucar.edu.sc/)", line 20, in <module>
>     from standard_script_setup import *
>   File "/glade/u/home/cacraig/cam_misc_tag/cime/CIME/Tools/standard_script_setup.py", line 33, in <module>
>     check_minimum_python_version(3, 6)
>   File "/glade/u/home/cacraig/cam_misc_tag/cime/CIME/Tools/standard_script_setup.py", line 30, in check_minimum_python_version
>     ), msg
> AssertionError: Python 3, minor version 6 is required, you have 3.4

The `-V` option is removed by PR https://github.com/ESMCI/ccs_config_cesm/pull/97 because the `NGPUS` env variable is not set properly on Derecho's compute node and the GPU run will crash accordingly. This issue can be resolved later on Derecho and this PR will add `-V` option back for PBS system to avoid the error above.