### PR TITLE
build RRTMGP code w/ -fno-openmp option

### DIFF
--- a/machines/Depends.cray
+++ b/machines/Depends.cray
@@ -1,4 +1,18 @@
 NOOPTOBJS= ice_boundary.o dyn_comp.o unicon.o
 
+# RRTMGP contains openmp directives for running on GPUs.  These directives need to be
+# disabled to allow building CAM with threading on CPUs enabled.
+RRTMGP_OBJS=\
+mo_fluxes_byband.o                       mo_rrtmgp_clr_all_sky.o \
+mo_zenith_angle_spherical_correction.o   mo_gas_concentrations.o \
+mo_aerosol_optics_rrtmgp_merra.o         mo_cloud_optics_rrtmgp.o \
+mo_gas_optics_rrtmgp.o                   mo_gas_optics_rrtmgp_kernels.o \
+mo_rte_sw.o                              mo_rte_lw.o \
+mo_rte_util_array_validation.o           mo_rte_util_array.o \
+mo_fluxes_broadband_kernels.o
+
 $(NOOPTOBJS): %.o: %.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FFLAGS_NOOPT) $(FREEFLAGS) $<
+
+$(RRTMGP_OBJS): %.o: %.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -h noomp $<

--- a/machines/Depends.gnu
+++ b/machines/Depends.gnu
@@ -1,2 +1,14 @@
 geopk.o:geopk.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fcray-pointer $<
+
+RRTMGP_OBJS=\
+mo_fluxes_byband.o                       mo_rrtmgp_clr_all_sky.o \
+mo_zenith_angle_spherical_correction.o   mo_gas_concentrations.o \
+mo_aerosol_optics_rrtmgp_merra.o         mo_cloud_optics_rrtmgp.o \
+mo_gas_optics_rrtmgp.o                   mo_gas_optics_rrtmgp_kernels.o \
+mo_rte_sw.o                              mo_rte_lw.o \
+mo_rte_util_array_validation.o           mo_rte_util_array.o \
+mo_fluxes_broadband_kernels.o
+
+$(RRTMGP_OBJS): %.o: %.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fno-openmp $<

--- a/machines/Depends.gnu
+++ b/machines/Depends.gnu
@@ -1,6 +1,8 @@
 geopk.o:geopk.F90
 	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fcray-pointer $<
 
+# RRTMGP contains openmp directives for running on GPUs.  These directives need to be
+# disabled to allow building CAM with threading on CPUs enabled.
 RRTMGP_OBJS=\
 mo_fluxes_byband.o                       mo_rrtmgp_clr_all_sky.o \
 mo_zenith_angle_spherical_correction.o   mo_gas_concentrations.o \

--- a/machines/Depends.intel
+++ b/machines/Depends.intel
@@ -33,6 +33,8 @@ micro_pumas_data.o \
 micro_pumas_utils.o \
 wv_sat_methods.o
 
+# RRTMGP contains openmp directives for running on GPUs.  These directives need to be
+# disabled to allow building CAM with threading on CPUs enabled.
 RRTMGP_OBJS=\
 mo_fluxes_byband.o                       mo_rrtmgp_clr_all_sky.o \
 mo_zenith_angle_spherical_correction.o   mo_gas_concentrations.o \
@@ -58,4 +60,4 @@ ifeq ($(DEBUG),FALSE)
 endif
 
 $(RRTMGP_OBJS): %.o: %.F90
-	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fno-openmp $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -qno-openmp $<

--- a/machines/Depends.intel
+++ b/machines/Depends.intel
@@ -33,6 +33,14 @@ micro_pumas_data.o \
 micro_pumas_utils.o \
 wv_sat_methods.o
 
+RRTMGP_OBJS=\
+mo_fluxes_byband.o                       mo_rrtmgp_clr_all_sky.o \
+mo_zenith_angle_spherical_correction.o   mo_gas_concentrations.o \
+mo_aerosol_optics_rrtmgp_merra.o         mo_cloud_optics_rrtmgp.o \
+mo_gas_optics_rrtmgp.o                   mo_gas_optics_rrtmgp_kernels.o \
+mo_rte_sw.o                              mo_rte_lw.o \
+mo_rte_util_array_validation.o           mo_rte_util_array.o \
+mo_fluxes_broadband_kernels.o
 
 ifeq ($(DEBUG),FALSE)
   $(PERFOBJS): %.o: %.F90
@@ -47,5 +55,7 @@ ifeq ($(DEBUG),FALSE)
 	  $(CC) -c $(INCLDIR) $(INCS) $(CFLAGS) -O3 -fp-model fast $<
   $(PUMAS_MG_OBJS): %.o: %.F90
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -no-fma -ftz -no-prec-sqrt -qoverride-limits -no-inline-max-total-size -inline-factor=200 -qopt-report=5 $<
-
 endif
+
+$(RRTMGP_OBJS): %.o: %.F90
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fno-openmp $<


### PR DESCRIPTION
In order to build CAM with the RRTMGP code for hybrid parallelization, it is necessary to disable the openmp directives in several RRTMGP files. That's because those directives are intended for running on GPUs and not for use of threads on CPUs.  The compilation fails in the RRTMGP files when trying to build for hybrid mode.
