### PR TITLE
Use the system-wide MPI wrapper script on Derecho

### DIFF
--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -21,7 +21,7 @@
     <MPI_GPU_WRAPPER_SCRIPT>get_local_rank</MPI_GPU_WRAPPER_SCRIPT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>/glade/work/rory/mpibind/mpibind</executable>
+      <executable>mpibind</executable>
       <arguments>
         <arg name="label"> --label</arg>
 	<arg name="buffer"> --line-buffer</arg>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -21,12 +21,7 @@
     <MPI_GPU_WRAPPER_SCRIPT>get_local_rank</MPI_GPU_WRAPPER_SCRIPT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>mpiexec</executable>
-      <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="buffer"> --line-buffer</arg>
-        <arg name="num_tasks" > -n {{ total_tasks }}</arg>
-      </arguments>
+      <executable>mpibind</executable>
     </mpirun>
     <module_system type="module" allow_error="true">
       <init_path lang="perl">$ENV{LMOD_ROOT}/lmod/init/perl</init_path>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -21,7 +21,12 @@
     <MPI_GPU_WRAPPER_SCRIPT>get_local_rank</MPI_GPU_WRAPPER_SCRIPT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
-      <executable>mpibind</executable>
+      <executable>/glade/work/rory/mpibind/mpibind</executable>
+      <arguments>
+        <arg name="label"> --label</arg>
+	<arg name="buffer"> --line-buffer</arg>
+	<arg name="separator"> -- </arg>
+      </arguments>
     </mpirun>
     <module_system type="module" allow_error="true">
       <init_path lang="perl">$ENV{LMOD_ROOT}/lmod/init/perl</init_path>


### PR DESCRIPTION
This PR introduces the system-wide `mpibind` wrapper script on Derecho, which will handle the MPI-only and hybrid MPI/OpenMP configurations automatically. The performance between the MPI-only and hybrid MPI/OpenMP configurations for the `F2000climo` compset and `f09_f09_mg17` grid is comparable on Derecho by using this script.

However, my tests indicate that the threading option in CAM does not work for the `f19_f19_mg17` grid (no matter using the `mpibind` script or manually adding the MPI arguments to the `mpiexec` command). According to the error message shown below, this is likely a code issue rather than a problem from the MPI/OpenMP configuration.
```
forrtl: severe (174): SIGSEGV, segmentation fault occurred
Image              PC                Routine            Line        Source
libpthread-2.31.s  000015466C91C8C0  Unknown               Unknown  Unknown
cesm.exe           0000000003859342  Unknown               Unknown  Unknown
cesm.exe           000000000385A2FE  Unknown               Unknown  Unknown
cesm.exe           0000000003859531  Unknown               Unknown  Unknown
cesm.exe           000000000240A789  advance_clubb_cor        2548  advance_clubb_core_module.F90
cesm.exe           0000000001BA127E  clubb_intr_mp_clu        3326  clubb_intr.F90
cesm.exe           00000000007A9903  physpkg_mp_tphysa        1716  physpkg.F90
cesm.exe           00000000007A7320  physpkg_mp_phys_r        1259  physpkg.F90
libiomp5.so        00001546682E4493  __kmp_invoke_micr     Unknown  Unknown
libiomp5.so        0000154668252533  Unknown               Unknown  Unknown
libiomp5.so        0000154668251470  Unknown               Unknown  Unknown
libiomp5.so        00001546682E51FF  Unknown               Unknown  Unknown
libpthread-2.31.s  000015466C9106EA  Unknown               Unknown  Unknown
libc-2.31.so       0000154667EA3A6F  clone                 Unknown  Unknown
```