### PR TITLE
workaround mpi-serial debug issue on derecho

### DIFF
--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -27,7 +27,7 @@
 	<arg name="buffer"> --line-buffer</arg>
 	<arg name="separator"> -- </arg>
       </arguments>
-    </mpirun>
+   </mpirun>
     <module_system type="module" allow_error="true">
       <init_path lang="perl">$ENV{LMOD_ROOT}/lmod/init/perl</init_path>
       <init_path lang="python">$ENV{LMOD_ROOT}/lmod/init/env_modules_python.py</init_path>
@@ -74,15 +74,13 @@
       <modules mpilib="mpich">
 	<command name="load">cray-mpich/8.1.27</command>
       </modules>
-      <modules mpilib="mpi-serial">
-        <command name="load">mpi-serial/2.3.0</command>
-      </modules>
 
       <modules mpilib="mpich" compiler="nvhpc" gpu_offload="!none">
         <command name="load">cuda/12.2.1</command>
       </modules>
 
       <modules mpilib="mpi-serial">
+        <command name="load">mpi-serial/2.3.0</command>
         <command name="load">netcdf/4.9.2</command>
       </modules>
 
@@ -91,14 +89,19 @@
         <command name="load">parallel-netcdf/1.12.3</command>
       </modules>
 
-      <modules DEBUG="TRUE">
-	<command name="load">parallelio/2.6.2-debug</command>
-	<command name="load">esmf/8.6.0b04-debug</command>
-      </modules>
-
       <modules DEBUG="FALSE">
 	<command name="load">parallelio/2.6.2</command>
-	<command name="load">esmf/8.6.0b04</command>
+	<command name="load">esmf/8.6.0</command>
+      </modules>
+
+      <modules DEBUG="TRUE" mpilib="mpi-serial">
+	<command name="load">parallelio/2.6.2</command>
+	<command name="load">esmf/8.6.0</command>
+      </modules>
+
+      <modules DEBUG="FALSE" mpilib="!mpi-serial">
+	<command name="load">parallelio/2.6.2-debug</command>
+	<command name="load">esmf/8.6.0-debug</command>
       </modules>
     </module_system>
 


### PR DESCRIPTION
Workaround the mpi-serial link issue by not using the debug build of pio and esmf when building with mpi-serial.  
Fixes #130 