### PR TITLE
Update the gpu wrapper script on Derecho

### DIFF
--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -18,7 +18,7 @@
     <MAX_CPUTASKS_PER_GPU_NODE>64</MAX_CPUTASKS_PER_GPU_NODE>
     <GPU_TYPE>none,a100</GPU_TYPE>
     <GPU_OFFLOAD>none,openacc,openmp,combined</GPU_OFFLOAD>
-    <MPI_GPU_WRAPPER_SCRIPT>get_local_rank</MPI_GPU_WRAPPER_SCRIPT>
+    <MPI_GPU_WRAPPER_SCRIPT>set_gpu_rank</MPI_GPU_WRAPPER_SCRIPT>
     <PROJECT_REQUIRED>TRUE</PROJECT_REQUIRED>
     <mpirun mpilib="default">
       <executable>mpibind</executable>


### PR DESCRIPTION
Since `ncarenv/23.09`, the MPI+GPU wrapper script on Derecho becomes `set_gpu_rank` and `get_local_rank` is deprecated. This is just a name change and its functionality remains the same.