### PR TITLE
Fix esmf/parallelio debug module settings for derecho.

### DIFF
--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -99,7 +99,7 @@
 	<command name="load">esmf/8.6.0</command>
       </modules>
 
-      <modules DEBUG="FALSE" mpilib="!mpi-serial">
+      <modules DEBUG="TRUE" mpilib="!mpi-serial">
 	<command name="load">parallelio/2.6.2-debug</command>
 	<command name="load">esmf/8.6.0-debug</command>
       </modules>


### PR DESCRIPTION
The esmf and parallelio module commends weren't being set when compiling with DEBUG turned on, and not using
mpi-serial.