### PR TITLE
Update the filenames for RRTMGP v1.7

### DIFF
--- a/machines/Depends.nvhpc
+++ b/machines/Depends.nvhpc
@@ -40,35 +40,24 @@ macrop_driver.o \
 shr_spfn_mod.o
 
 RRTMGP_OBJS=\
-mo_rte_util_array.o \
-mo_rte_sw.o \
-mo_rte_lw.o \
-mo_cloud_optics.o \
-mo_gas_optics_rrtmgp.o \
+rrtmgp_allsky.o \
+rrtmgp_rfmip_lw.o \
+rrtmgp_rfmip_sw.o \
+mo_fluxes_byband.o \
+mo_zenith_angle_spherical_correction.o \
+mo_rrtmgp_clr_all_sky.o \
 mo_gas_concentrations.o \
+mo_aerosol_optics_rrtmgp_merra.o \
+mo_cloud_optics_rrtmgp.o \
+mo_gas_optics_rrtmgp.o \
+mo_gas_optics_rrtmgp_kernels.o \
+mo_rte_lw.o \
+mo_rte_sw.o \
+mo_rte_util_array_validation.o \
+mo_rte_util_array.o \
 mo_fluxes_broadband_kernels.o \
-mo_fluxes_byband_kernels.o \
-mo_rrtmgp_util_reorder_kernels.o \
-mo_compute_bc.o\
-mo_fluxes_byband.o\
-mo_fluxes_bygpoint.o\
-mo_heating_rates.o\
-mo_rrtmgp_clr_all_sky.o\
-mo_cloud_sampling.o\
-mo_solar_variability.o\
-mo_gas_optics.o\
-mo_rrtmgp_constants.o\
-mo_rrtmgp_util_reorder.o\
-mo_rrtmgp_util_string.o\
-mo_fluxes.o\
-mo_optical_props.o\
-mo_rte_config.o\
-mo_rte_kind.o\
-mo_source_functions.o\
-mo_optical_props_kernels.o\
-mo_rte_solver_kernels.o\
-rrtmgp_driver.o\
-mo_gas_optics_kernels.o
+mo_rte_solver_kernels.o \
+mo_optical_props_kernels.o
 
 ifeq ($(DEBUG),FALSE)
   $(PERFOBJS): %.o: %.F90


### PR DESCRIPTION
RRTMGP will be brought into CAM as the new radiation scheme (https://github.com/ESCOMP/CAM/pull/909).

Since the tag `v1.7`, a few files containing the GPU directives have been renamed. Thus we need to update the `Depends.nvhpc` file accordingly to apply the GPU flags correctly.