### PR TITLE
change the queue used for st_archive on derecho

### DIFF
--- a/machines/config_batch.xml
+++ b/machines/config_batch.xml
@@ -370,8 +370,8 @@
       <directive> -l select={{ num_nodes }}:ncpus={{ max_cputasks_per_gpu_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}:mem=480GB:ngpus={{ ngpus_per_node }}:mps=1 </directive>
     </directives>
     <queues>
+      <queue walltimemax="1:00:00" jobmin="1" jobmax="64" >develop</queue>
       <queue walltimemax="12:00:00" nodemin="1" nodemax="2488" >main</queue>
-      <queue walltimemax="1:00:00" nodemin="1" nodemax="2" >develop</queue>
     </queues>
   </batch_system>
 


### PR DESCRIPTION
Use the develop queue on derecho for st_archive, this is a shared queue and
avoids using a full node for this simple task.

Tested using ERR.f19_g17.A.derecho_intel.