### PR TITLE
add polarcap grid, fix mpasa15-3 naming issues

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -249,6 +249,12 @@
     <desc>ne0np4.ARCTICGRIS.ne30x8 is a Spectral Elem 1-deg grid with a 1/8 deg refined region over Greenland:</desc>
     <support>Test support only</support>
   </domain>
+  <domain name="ne0np4.POLARCAP.ne30x4">
+    <nx>186194</nx> <ny>1</ny>
+    <mesh>/glade/work/aherring/grids/var-res/ne0np4.POLARRES.ne30x4/grids/polarcap/POLARCAP_ne30x4_np4_MESH_cdf5.nc</mesh>
+    <desc>ne0np4.POLARCAP.ne30x4 is a Spectral Elem 1-deg grid with a 1/4 deg refined region over the Arctic and Antarctica:</desc>
+    <support>Test support only</support>
+  </domain>
 
   <!-- CAM/MPAS meshes -->
   <domain name="mpasa480">

--- a/modelgrid_aliases_mct.xml
+++ b/modelgrid_aliases_mct.xml
@@ -1137,10 +1137,10 @@
     <mask>gx1v7</mask>
   </model_grid>
 
-  <model_grid alias="mpasa15-3_mpasa15-3" not_compset="_POP">
-    <grid name="atm">mpasa15-3</grid>
-    <grid name="lnd">mpasa15-3</grid>
-    <grid name="ocnice">mpasa15-3</grid>
+  <model_grid alias="mpasa15-3conus_mpasa15-3conus" not_compset="_POP">
+    <grid name="atm">mpasa15-3conus</grid>
+    <grid name="lnd">mpasa15-3conus</grid>
+    <grid name="ocnice">mpasa15-3conus</grid>
     <mask>gx1v7</mask>
   </model_grid>
 

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1245,6 +1245,13 @@
     <mask>tx0.1v2</mask>
   </model_grid>
 
+  <model_grid alias="ne0POLARCAPne30x4_ne0POALRCAPne30x4_mt12" not_compset="_POP">
+    <grid name="atm">ne0np4.POLARCAP.ne30x4</grid>
+    <grid name="lnd">ne0np4.POLARCAP.ne30x4</grid>
+    <grid name="ocnice">ne0np4.POLARCAP.ne30x4</grid>
+    <mask>tx0.1v2</mask>
+  </model_grid>
+
   <!-- MPAS-A grids -->
 
   <model_grid alias="mpasa480_mpasa480" not_compset="_POP">
@@ -1296,18 +1303,11 @@
     <mask>gx1v7</mask>
   </model_grid>
 
-  <model_grid alias="mpasa15-3_mpasa15-3" not_compset="_POP">
-    <grid name="atm">mpasa15-3</grid>
-    <grid name="lnd">mpasa15-3</grid>
-    <grid name="ocnice">mpasa15-3</grid>
-    <mask>gx1v7</mask>
-  </model_grid>
-
-  <model_grid alias="mpasa15-3-conus_mpasa15-3-conus" not_compset="_POP">
-    <grid name="atm">mpasa15-3</grid>
-    <grid name="lnd">mpasa15-3</grid>
-    <grid name="ocnice">mpasa15-3</grid>
-    <mask>gx1v7</mask>
+  <model_grid alias="mpasa15-3-conus_mpasa15-3-conus_mt13" not_compset="_POP">
+    <grid name="atm">mpasa15-3conus</grid>
+    <grid name="lnd">mpasa15-3conus</grid>
+    <grid name="ocnice">mpasa15-3conus</grid>
+    <mask>tx0.1v3</mask>
   </model_grid>
 
   <model_grid alias="mpasa7p5_mpasa7p5_mg17" not_compset="_POP">

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1245,7 +1245,7 @@
     <mask>tx0.1v2</mask>
   </model_grid>
 
-  <model_grid alias="ne0POLARCAPne30x4_ne0POALRCAPne30x4_mt12" not_compset="_POP">
+  <model_grid alias="ne0POLARCAPne30x4_ne0POLARCAPne30x4_mt12" not_compset="_POP">
     <grid name="atm">ne0np4.POLARCAP.ne30x4</grid>
     <grid name="lnd">ne0np4.POLARCAP.ne30x4</grid>
     <grid name="ocnice">ne0np4.POLARCAP.ne30x4</grid>


### PR DESCRIPTION
Fixes #152 
Fixes #153 

I verified the new POLARCAP grid alias builds and run with this new ccs_config external. Would someone mind adding the mesh and scrip files to inputdata/share/? Ill then update the paths.

```
/glade/work/aherring/grids/var-res/ne0np4.POLARRES.ne30x4/grids/polarcap/POLARCAP_ne30x4_np4_MESH_cdf5.nc
/glade/work/aherring/grids/var-res/ne0np4.POLARRES.ne30x4/grids/polarcap/POLARCAP_ne30x4_np4_SCRIP.nc
```

Should I first add a creation date to the grid file names? Who should I assign as a reviewer?
