### PR TITLE
Adding glc supporting grid aliases for CESM3

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -431,6 +431,20 @@
     <grid name="ocnice">tx2_3v2</grid>
   </model_grid>
 
+  <model_grid alias="f09_t232_gris4">
+    <grid name="atm">0.9x1.25</grid>
+    <grid name="lnd">0.9x1.25</grid>
+    <grid name="ocnice">tx2_3v2</grid>
+    <grid name="glc">gris4</grid>
+  </model_grid>
+
+    <model_grid alias="f09_t232_ais8gris4">
+    <grid name="atm">0.9x1.25</grid>
+    <grid name="lnd">0.9x1.25</grid>
+    <grid name="ocnice">tx2_3v2</grid>
+    <grid name="glc">ais8:gris4</grid>
+  </model_grid>
+
   <model_grid alias="T62_g16" not_compset="_CAM">
     <grid name="atm">T62</grid>
     <grid name="lnd">T62</grid>
@@ -896,6 +910,22 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="ne30pg3_g17_gris4">
+    <grid name="atm">ne30np4.pg3</grid>
+    <grid name="lnd">ne30np4.pg3</grid>
+    <grid name="ocnice">gx1v7</grid>
+    <grid name="glc">gris4</grid>
+    <mask>gx1v7</mask>
+  </model_grid>
+
+  <model_grid alias="ne30pg3_g17_ais8gris4">
+    <grid name="atm">ne30np4.pg3</grid>
+    <grid name="lnd">ne30np4.pg3</grid>
+    <grid name="ocnice">gx1v7</grid>
+    <grid name="glc">ais8:gris4</grid>
+    <mask>gx1v7</mask>
+  </model_grid>
+
   <model_grid alias="ne30pg3_t061">
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
@@ -907,6 +937,14 @@
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
     <grid name="ocnice">tx2_3v2</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
+    <model_grid alias="ne30pg3_t232_gris4">
+    <grid name="atm">ne30np4.pg3</grid>
+    <grid name="lnd">ne30np4.pg3</grid>
+    <grid name="ocnice">tx2_3v2</grid>
+    <grid name="glc">gris4</grid>
     <mask>tx2_3v2</mask>
   </model_grid>
 

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -940,7 +940,7 @@
     <mask>tx2_3v2</mask>
   </model_grid>
 
-    <model_grid alias="ne30pg3_t232_gris4">
+  <model_grid alias="ne30pg3_t232_gris4">
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
     <grid name="ocnice">tx2_3v2</grid>
@@ -948,6 +948,14 @@
     <mask>tx2_3v2</mask>
   </model_grid>
 
+  <model_grid alias="ne30pg3_t232_ais8gris4">
+    <grid name="atm">ne30np4.pg3</grid>
+    <grid name="lnd">ne30np4.pg3</grid>
+    <grid name="ocnice">tx2_3v2</grid>
+    <grid name="glc">ais8:gris4</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+ 
   <model_grid alias="ne30_f19_g16">
     <grid name="atm">ne30np4</grid>
     <grid name="lnd">1.9x2.5</grid>


### PR DESCRIPTION
This is a relatively low priority PR, but an easy one too. If we want to run with active glaciers in CESM3 simulations, we will need grid aliases for the common CESM3 grids plus glaciers. I have added some options here for testing as we get closer.

I tested these in the CISM-Wrapper repo (IG cases), but I haven't tested with a full B1850G in CESM yet. Let me know if that is necessary.