### PR TITLE
Update the GPU settings on Derecho

### DIFF
--- a/machines/Depends.nvhpc
+++ b/machines/Depends.nvhpc
@@ -33,6 +33,7 @@ micro_mg1_0.o \
 micro_pumas_v1.o \
 micro_pumas_data.o \
 micro_pumas_utils.o \
+pumas_stochastic_collect_tau.o \
 micro_pumas_cam.o \
 wv_sat_methods.o \
 wv_saturation.o \
@@ -73,5 +74,5 @@ ifeq ($(DEBUG),FALSE)
   $(PUMAS_OBJS): %.o: %.F90
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -fastsse -Mnofma -Mflushz -Mfprelaxed=sqrt $(GPUFLAGS) $<
   $(RRTMGP_OBJS): %.o: %.F90
-	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(GPUFLAGS) $<
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $<
 endif

--- a/machines/Depends.nvhpc
+++ b/machines/Depends.nvhpc
@@ -74,5 +74,5 @@ ifeq ($(DEBUG),FALSE)
   $(PUMAS_OBJS): %.o: %.F90
 	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -fastsse -Mnofma -Mflushz -Mfprelaxed=sqrt $(GPUFLAGS) $<
   $(RRTMGP_OBJS): %.o: %.F90
-	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $<
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(GPUFLAGS) $<
 endif

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -64,7 +64,7 @@
         <command name="load">cray-libsci/23.02.1.1</command>
       </modules>
       <modules compiler="nvhpc">
-        <command name="load">nvhpc/23.7</command>
+        <command name="load">nvhpc/24.3</command>
       </modules>
 
       <modules>
@@ -122,6 +122,6 @@
       <env name="ESMF_RUNTIME_PROFILE_OUTPUT">SUMMARY</env>
     </environment_variables>
     <environment_variables compiler="nvhpc" gpu_offload="!none">
-      <env name="RTE_KERNELS">openacc</env>
+      <env name="NCAR_LIBS_CUDA">-lcuda -lcudart</env>
     </environment_variables>
   </machine>


### PR DESCRIPTION
This PR:
- updates the NVHPC compiler version to `nvhpc/24.3` on Derecho, which fixes the `EOSHIFT` bug reported at https://github.com/ESCOMP/CAM/issues/883.
- enables the GPU flags for a new source code in PUMAS so that the `tau` warm rain scheme runs correctly on the GPU.
- updates the CUDA linker flags on Derecho when the GPU options are enabled.
- removes unused env variable for RRTMGP GPU code.
