### PR TITLE
Derecho runs requesting ≥64 jobs go to main, not develop

### DIFF
--- a/machines/derecho/config_batch.xml
+++ b/machines/derecho/config_batch.xml
@@ -12,8 +12,8 @@
     <directive> -l select={{ num_nodes }}:ncpus={{ max_cputasks_per_gpu_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}:mem=480GB:ngpus={{ ngpus_per_node }}:mps=1 </directive>
   </directives>
   <queues>
-    <queue walltimemax="1:00:00" jobmin="1" jobmax="64" >develop</queue>
-    <queue walltimemax="12:00:00" nodemin="65" nodemax="318464" >main</queue>
+    <queue walltimemax="1:00:00" jobmin="1" jobmax="63" >develop</queue>
+    <queue walltimemax="12:00:00" nodemin="64" nodemax="318464" >main</queue>
   </queues>
 </batch_system>
 

--- a/machines/derecho/config_batch.xml
+++ b/machines/derecho/config_batch.xml
@@ -13,7 +13,7 @@
   </directives>
   <queues>
     <queue walltimemax="1:00:00" jobmin="1" jobmax="64" >develop</queue>
-    <queue walltimemax="12:00:00" nodemin="1" nodemax="2488" >main</queue>
+    <queue walltimemax="12:00:00" nodemin="65" nodemax="318464" >main</queue>
   </queues>
 </batch_system>
 

--- a/machines/derecho/config_batch.xml
+++ b/machines/derecho/config_batch.xml
@@ -13,7 +13,7 @@
   </directives>
   <queues>
     <queue walltimemax="1:00:00" jobmin="1" jobmax="63" >develop</queue>
-    <queue walltimemax="12:00:00" nodemin="64" nodemax="318464" >main</queue>
+    <queue walltimemax="12:00:00" jobmin="64" jobmax="318464" >main</queue>
   </queues>
 </batch_system>
 


### PR DESCRIPTION
So, e.g., tests with `128x1` go to main instead of develop. However, `64x2` would still go to develop—not sure if that's what we want.

Resolves #182.