### PR TITLE
fix the default grid name for wav components

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -19,9 +19,9 @@
     <grid name="glc"       compset="DGLC"        >gris4</grid>
     <grid name="glc"       compset="XGLC"        >gris4</grid>
     <grid name="wav"       compset="SWAV"        >null</grid>
-    <grid name="wav"       compset="DWAV"        >wg37</grid>
-    <grid name="wav"       compset="WW3"         >wg37</grid>
-    <grid name="wav"       compset="XWAV"        >wg37</grid>
+    <grid name="wav"       compset="DWAV"        >wgx3v7</grid>
+    <grid name="wav"       compset="WW3"         >wgx3v7</grid>
+    <grid name="wav"       compset="XWAV"        >wgx3v7</grid>
     <grid name="iac"       compset="SIAC"        >null</grid>
   </model_grid_defaults>
 


### PR DESCRIPTION
Instead of the short name, we need to specify the full grid name as the default.