### PR TITLE
enable t232 mask on default land grid

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -406,6 +406,7 @@
     <grid name="atm">0.9x1.25</grid>
     <grid name="lnd">0.9x1.25</grid>
     <grid name="ocnice">tx2_3v2</grid>
+    <mask>tx2_3v2</mask>
   </model_grid>
 
   <model_grid alias="f09_t232_gris4">


### PR DESCRIPTION
mask information was  needed to run an I-case with the f09_t232 grid.  Is this true for other grids too?