### PR TITLE
add ne30pg3_ne30pg3_t232

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1129,6 +1129,13 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="ne30pg3_ne30pg3_t232" not_compset="_MOM">
+    <grid name="atm">ne30np4.pg3</grid>
+    <grid name="lnd">ne30np4.pg3</grid>
+    <grid name="ocnice">ne30np4.pg3</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="ne60pg3_ne60pg3_mg17" not_compset="_MOM|_CLM">
     <grid name="atm">ne60np4.pg3</grid>
     <grid name="lnd">ne60np4.pg3</grid>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1129,7 +1129,7 @@
     <mask>gx1v7</mask>
   </model_grid>
 
-  <model_grid alias="ne30pg3_ne30pg3_t232" not_compset="_MOM">
+  <model_grid alias="ne30pg3_ne30pg3_mt232" not_compset="_MOM">
     <grid name="atm">ne30np4.pg3</grid>
     <grid name="lnd">ne30np4.pg3</grid>
     <grid name="ocnice">ne30np4.pg3</grid>


### PR DESCRIPTION
Add grid for CAM F and QP compsets which uses the MOM ocean mask for consistency with B compset mask.
