### PR TITLE
add toronto backup for inputdata

### DIFF
--- a/config_inputdata.xml
+++ b/config_inputdata.xml
@@ -24,6 +24,11 @@
     <address>https://svn-ccsm-inputdata.cgd.ucar.edu/trunk/inputdata</address>
   </server>
 
+  <server>
+    <protocol>wget</protocol>
+    <address>https://redoak.cs.toronto.edu/twitcher/ows/proxy/thredds/fileServer/datasets/CESM/inputdata/</address>
+  </server>
+  
   <server CLM_USRDAT_NAME="NEON">
     <comment> NEON Tower data for datm </comment>
     <protocol>wget</protocol>


### PR DESCRIPTION
Adds a server in Toronto as a backup inputdata server should NCAR go offline for any reason.  