### PR TITLE
Add F compset grids w/ mt232 mask

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -585,6 +585,13 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="f09_f09_mt232" not_compset="_MOM" >
+    <grid name="atm">0.9x1.25</grid>
+    <grid name="lnd">0.9x1.25</grid>
+    <grid name="ocnice">0.9x1.25</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="f09_f09_rHDMA_mg17" not_compset="_MOM" compset="MIZUROUTE">
     <grid name="atm">0.9x1.25</grid>
     <grid name="lnd">0.9x1.25</grid>
@@ -706,6 +713,13 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="f19_f19_mt232" not_compset="_MOM">
+    <grid name="atm">1.9x2.5</grid>
+    <grid name="lnd">1.9x2.5</grid>
+    <grid name="ocnice">1.9x2.5</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="f19_f19_rHDMA_mg17" not_compset="_MOM" compset="MIZUROUTE">
     <grid name="atm">1.9x2.5</grid>
     <grid name="lnd">1.9x2.5</grid>
@@ -779,6 +793,13 @@
     <mask>gx3v7</mask>
   </model_grid>
 
+  <model_grid alias="f10_f10_mt232" not_compset="_MOM">
+    <grid name="atm">10x15</grid>
+    <grid name="lnd">10x15</grid>
+    <grid name="ocnice">10x15</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="f10_f10_ais8_mg37" compset="_CISM|_DGLC" not_compset="_MOM">
     <grid name="atm">10x15</grid>
     <grid name="lnd">10x15</grid>
@@ -810,13 +831,6 @@
   </model_grid>
 
   <!--  spectral element grids -->
-  <model_grid alias="ne3pg3_ne3pg3_mg37" not_compset="_MOM">
-    <grid name="atm">ne3np4.pg3</grid>
-    <grid name="lnd">ne3np4.pg3</grid>
-    <grid name="ocnice">ne3np4.pg3</grid>
-    <mask>gx3v7</mask>
-  </model_grid>
-
   <model_grid alias="ne3_ne3_mg37" not_compset="_MOM">
     <grid name="atm">ne3np4</grid>
     <grid name="lnd">ne3np4</grid>
@@ -1064,6 +1078,13 @@
 
   <!--  spectral element grids with 2x2 FVM physics grid -->
 
+  <model_grid alias="ne3pg2_ne3pg2_mt232" not_compset="_MOM">
+    <grid name="atm">ne3np4.pg2</grid>
+    <grid name="lnd">ne3np4.pg2</grid>
+    <grid name="ocnice">ne3np4.pg2</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="ne5pg2_ne5pg2_mg37" not_compset="_MOM">
     <grid name="atm">ne5np4.pg2</grid>
     <grid name="lnd">ne5np4.pg2</grid>
@@ -1071,11 +1092,18 @@
     <mask>gx3v7</mask>
   </model_grid>
 
-  <model_grid alias="ne30pg2_ne30pg2_mg17">
+  <model_grid alias="ne30pg2_ne30pg2_mg17" not_compset="_MOM">
     <grid name="atm">ne30np4.pg2</grid>
     <grid name="lnd">ne30np4.pg2</grid>
     <grid name="ocnice">ne30np4.pg2</grid>
     <mask>gx1v7</mask>
+  </model_grid>
+
+  <model_grid alias="ne30pg2_ne30pg2_mt232" not_compset="_MOM">
+    <grid name="atm">ne30np4.pg2</grid>
+    <grid name="lnd">ne30np4.pg2</grid>
+    <grid name="ocnice">ne30np4.pg2</grid>
+    <mask>tx2_3v2</mask>
   </model_grid>
 
   <model_grid alias="ne60pg2_ne60pg2_mg17" not_compset="_MOM|_CLM">
@@ -1108,6 +1136,20 @@
 
   <!--  spectral element grids with 3x3 FVM physics grid -->
 
+  <model_grid alias="ne3pg3_ne3pg3_mg37" not_compset="_MOM">
+    <grid name="atm">ne3np4.pg3</grid>
+    <grid name="lnd">ne3np4.pg3</grid>
+    <grid name="ocnice">ne3np4.pg3</grid>
+    <mask>gx3v7</mask>
+  </model_grid>
+
+  <model_grid alias="ne3pg3_ne3pg3_mt232" not_compset="_MOM">
+    <grid name="atm">ne3np4.pg3</grid>
+    <grid name="lnd">ne3np4.pg3</grid>
+    <grid name="ocnice">ne3np4.pg3</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="ne5pg3_ne5pg3_mg37" not_compset="_MOM">
     <grid name="atm">ne5np4.pg3</grid>
     <grid name="lnd">ne5np4.pg3</grid>
@@ -1120,6 +1162,13 @@
     <grid name="lnd">ne16np4.pg3</grid>
     <grid name="ocnice">ne16np4.pg3</grid>
     <mask>gx1v7</mask>
+  </model_grid>
+
+  <model_grid alias="ne16pg3_ne16pg3_mt232" not_compset="_MOM">
+    <grid name="atm">ne16np4.pg3</grid>
+    <grid name="lnd">ne16np4.pg3</grid>
+    <grid name="ocnice">ne16np4.pg3</grid>
+    <mask>tx2_3v2</mask>
   </model_grid>
 
   <model_grid alias="ne30pg3_ne30pg3_mg17" not_compset="_MOM">

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1338,6 +1338,13 @@
     <mask>gx1v7</mask>
   </model_grid>
 
+  <model_grid alias="mpasa480_mpasa480_mt232" not_compset="_MOM">
+    <grid name="atm">mpasa480</grid>
+    <grid name="lnd">mpasa480</grid>
+    <grid name="ocnice">mpasa480</grid>
+    <mask>tx2_3v2</mask>
+  </model_grid>
+
   <model_grid alias="mpasa240_mpasa240" not_compset="_MOM">
     <grid name="atm">mpasa240</grid>
     <grid name="lnd">mpasa240</grid>


### PR DESCRIPTION
Continue to replace POP masks by MOM mt232 for cam testing with F compsets.