### PR TITLE
Backout gcc update

### DIFF
--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -1,7 +1,7 @@
 <machine MACH="derecho">
     <DESC>NCAR AMD EPYC system</DESC>
     <OS>CNL</OS>
-    <COMPILERS>intel,gnu,nvhpc,cce</COMPILERS>
+    <COMPILERS>intel,gnu,nvhpc,cray</COMPILERS>
     <MPILIBS>mpich</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
@@ -97,12 +97,7 @@
         <command name="load">parallel-netcdf/1.12.3</command>
       </modules>
 
-      <modules DEBUG="FALSE" compiler="!gnu">
-	<command name="load">parallelio/2.6.4</command>
-	<command name="load">esmf/8.8.0</command>
-      </modules>
-
-      <modules DEBUG="TRUE" mpilib="mpi-serial" compiler="!gnu">
+      <modules compiler="!gnu">
 	<command name="load">parallelio/2.6.4</command>
 	<command name="load">esmf/8.8.0</command>
       </modules>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -36,13 +36,23 @@
       <cmd_path lang="python">$ENV{LMOD_ROOT}/lmod/libexec/lmod python</cmd_path>
       <cmd_path lang="sh">module</cmd_path>
       <cmd_path lang="csh">module</cmd_path>
-      <modules>
+      <modules compiler="!gnu">
 	<command name="load">cesmdev/1.0</command>
 	<command name="load">ncarenv/24.12</command>
         <command name="purge"/>
         <command name="load">conda/latest</command>
         <command name="load">nco</command>
 	<command name="load">craype</command>
+        <command name="load">cmake</command>
+      </modules>
+      <modules compiler="gnu">
+	<command name="load">cesmdev/1.0</command>
+	<command name="load">ncarenv/23.09</command>
+        <command name="purge"/>
+        <command name="load">conda/latest</command>
+        <command name="load">nco</command>
+	<command name="load">craype</command>
+        <command name="load">cmake</command>
       </modules>
       <modules compiler="intel">
         <command name="load">intel/2024.2.1</command>
@@ -53,19 +63,20 @@
         <command name="load">cray-libsci/24.03.0</command>
       </modules>
       <modules compiler="gnu">
-        <command name="load">gcc/12.4.0</command>
-        <command name="load">cray-libsci/24.03.0</command>
+        <command name="load">gcc/12.2.0</command>
+        <command name="load">cray-libsci/23.09.1.1</command>
       </modules>
       <modules compiler="nvhpc">
         <command name="load">nvhpc/24.11</command>
       </modules>
-
       <modules>
-	<command name="load">ncarcompilers/1.0.0</command>
-        <command name="load">cmake</command>
+        <command name="load">ncarcompilers/1.0.0</command>
       </modules>
-      <modules mpilib="mpich">
+      <modules mpilib="mpich" compiler="!gnu">
 	<command name="load">cray-mpich/8.1.29</command>
+      </modules>
+      <modules mpilib="mpich" compiler="gnu">
+	<command name="load">cray-mpich/8.1.27</command>
       </modules>
 
       <modules mpilib="mpich" compiler="nvhpc" gpu_type="!none">
@@ -77,25 +88,34 @@
         <command name="load">netcdf/4.9.2</command>
       </modules>
 
-      <modules mpilib="!mpi-serial">
+      <modules mpilib="!mpi-serial" compiler="!gnu">
         <command name="load">netcdf-mpi/4.9.2</command>
         <command name="load">parallel-netcdf/1.14.0</command>
       </modules>
+      <modules mpilib="!mpi-serial" compiler="gnu">
+        <command name="load">netcdf-mpi/4.9.2</command>
+        <command name="load">parallel-netcdf/1.12.3</command>
+      </modules>
 
-      <modules DEBUG="FALSE">
+      <modules DEBUG="FALSE" compiler="!gnu">
 	<command name="load">parallelio/2.6.4</command>
 	<command name="load">esmf/8.8.0</command>
       </modules>
 
-      <modules DEBUG="TRUE" mpilib="mpi-serial">
+      <modules DEBUG="TRUE" mpilib="mpi-serial" compiler="!gnu">
 	<command name="load">parallelio/2.6.4</command>
 	<command name="load">esmf/8.8.0</command>
       </modules>
 
-      <modules DEBUG="TRUE" mpilib="!mpi-serial">
-	<command name="load">parallelio/2.6.4-debug</command>
-	<command name="load">esmf/8.8.0</command>
+      <modules DEBUG="TRUE"  compiler="gnu">
+	<command name="load">parallelio/2.6.2-debug</command>
+	<command name="load">esmf/8.6.0-debug</command>
       </modules>
+      <modules DEBUG="FALSE" compiler="gnu">
+	<command name="load">parallelio/2.6.2</command>
+	<command name="load">esmf/8.6.0</command>
+      </modules>
+
     </module_system>
 
     <environment_variables>


### PR DESCRIPTION
Reverts gcc compiler to gcc/12.2.0 due to an issue found in cice in SMS_D.ne30pg3_t232.BLT1850.derecho_gnu.allactive-defaultio