### PR TITLE
fix aliases for C48_C48_mg17, C96_C96_mg17, C192_C192_mg17

### DIFF
--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1467,14 +1467,14 @@
     <mask>gx1v7</mask>
   </model_grid>
 
-  <model_grid alias="C24_C24_mg17" not_compset="_MOM">
+  <model_grid alias="C48_C48_mg17" not_compset="_MOM">
     <grid name="atm">C48</grid>
     <grid name="lnd">C48</grid>
     <grid name="ocnice">C48</grid>
     <mask>gx1v7</mask>
   </model_grid>
 
-  <model_grid alias="C24_C24_mg17" not_compset="_MOM">
+  <model_grid alias="C96_C96_mg17" not_compset="_MOM">
     <grid name="atm">C96</grid>
     <grid name="lnd">C96</grid>
     <grid name="ocnice">C96</grid>
@@ -1503,7 +1503,7 @@
     <mask>tx0.25v1</mask>
   </model_grid>
 
-  <model_grid alias="C24_C24_mg17" not_compset="_MOM">
+  <model_grid alias="C192_C192_mg17" not_compset="_MOM">
     <grid name="atm">C192</grid>
     <grid name="lnd">C192</grid>
     <grid name="ocnice">C192</grid>


### PR DESCRIPTION
The aliases C48_C48_mg17, C96_C96_mg17, C192_C192_mg17 have all somehow been overwritten with C24_C24_mg17.