### PR TITLE
use older mpi-serial with gnu on derecho

### DIFF
--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -88,8 +88,12 @@
         <command name="load">cuda/12.2.1</command>
       </modules>
 
-      <modules mpilib="mpi-serial">
+      <modules mpilib="mpi-serial" compiler="!gnu">
         <command name="load">mpi-serial/2.5.0</command>
+        <command name="load">netcdf/4.9.2</command>
+      </modules>
+      <modules mpilib="mpi-serial" compiler="gnu">
+        <command name="load">mpi-serial/2.3.0</command>
         <command name="load">netcdf/4.9.2</command>
       </modules>
 


### PR DESCRIPTION
Fixes #233 