### PR TITLE
Increase default wallclock time for cupid

### DIFF
--- a/machines/config_workflow.xml
+++ b/machines/config_workflow.xml
@@ -56,7 +56,7 @@
       <runtime_parameters MACH="derecho">
         <task_count>1</task_count>
         <tasks_per_node>1</tasks_per_node>
-        <walltime>0:20:00</walltime>
+        <walltime>0:40:00</walltime>
       </runtime_parameters>
     </job>
   </workflow_jobs>


### PR DESCRIPTION
We would like to increase the default wallclock time for running CUPiD.

[Relevant issue](https://github.com/NCAR/CUPiD/issues/245)