### PR TITLE
Update default files for mpaso and mpassi

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -405,8 +405,8 @@
     <support>Experimental tripole ocean grid</support>
   </domain>
     <domain name="oQU480">
-      <nx>7234</nx>  <ny>1</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU480/oQU480_ESMFmesh.nc</mesh>
+      <nx>1813</nx>  <ny>1</ny>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU480/oQU480_ESMFmesh.250721.nc</mesh>
       <desc>oQU480 is a MPAS ocean grid that is roughly 4 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>
@@ -429,8 +429,8 @@
       <support>Experimental, under development</support>
     </domain>
     <domain name="oQU060">
-      <nx>115494</nx>  <ny>1</ny>
-      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU060/oQU060_ESMFmesh.230907.nc</mesh>
+      <nx>115493</nx>  <ny>1</ny>
+      <mesh driver="nuopc">$DIN_LOC_ROOT/ocn/mpas-o/oQU060/oQU060_ESMFmesh.241221.nc</mesh>
       <desc>oQU060 is a MPAS ocean grid that is roughly 1/2 degree resolution:</desc>
       <support>Experimental, under development</support>
     </domain>

--- a/maps_nuopc.xml
+++ b/maps_nuopc.xml
@@ -94,6 +94,14 @@
       <map name="ROF2OCN_LIQ_RMAPNAME">cpl/gridmaps/rJRA025/map_jra_to_tx2_3_nnsm_e250r250_241211.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">cpl/gridmaps/rJRA025/map_jra_to_tx2_3_nnsm_e250r250_241211.nc</map>
     </gridmap>
+    <gridmap rof_grid="rx1" ocn_grid="oQU480" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_drof_qu480.250721.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_drof_qu480.250721.nc</map>
+    </gridmap>
+    <gridmap rof_grid="r05" ocn_grid="oQU480" >
+      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_mosart_qu480.250721.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_mosart_qu480.250721.nc</map>
+    </gridmap>
     <gridmap rof_grid="rx1" ocn_grid="oQU120" >
       <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_drof_qu120.230123.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_drof_qu120.230123.nc</map>
@@ -103,16 +111,16 @@
       <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_mosart_qu120.230123.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="oQU060" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_mosart_qu060.230613.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_mosart_qu060.230613.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_mosart_qu060.241221.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_mosart_qu060.241221.nc</map>
     </gridmap>
     <gridmap rof_grid="JRA025v2" ocn_grid="oQU120" >
       <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_jra_qu120.230517.nc</map>
       <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_jra_qu120.230517.nc</map>
     </gridmap>
     <gridmap rof_grid="JRA025v2" ocn_grid="oQU060" >
-      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_jra_qu060.230613.nc</map>
-      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_jra_qu060.230613.nc</map>
+      <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_jra_qu060.241221.nc</map>
+      <map name="ROF2OCN_ICE_RMAPNAME">rof/remap/wght_file_jra_qu060.241221.nc</map>
     </gridmap>
     <gridmap rof_grid="r05" ocn_grid="oQU030" >
       <map name="ROF2OCN_LIQ_RMAPNAME">rof/remap/wght_file_mosart_qu030.241221.nc</map>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -423,6 +423,14 @@
     <grid name="glc">ais8:gris4</grid>
   </model_grid>
 
+  <!-- EarthWorks Specific, MPAS-O+ROF -->
+  <model_grid alias="T62_oQU480" not_compset="_CAM">
+    <grid name="atm">T62</grid>
+    <grid name="lnd">T62</grid>
+    <grid name="ocnice">oQU480</grid>
+    <mask>oQU480</mask>
+  </model_grid>
+
   <model_grid alias="T62_oQU120" not_compset="_CAM">
     <grid name="atm">T62</grid>
     <grid name="lnd">T62</grid>
@@ -430,7 +438,6 @@
     <mask>oQU120</mask>
   </model_grid>
 
-  <!-- EarthWorks Specific, MPAS-O+ROF -->
   <model_grid alias="TL319_oQU120" not_compset="_CAM">
     <grid name="atm">TL319</grid>
     <grid name="lnd">TL319</grid>


### PR DESCRIPTION
The file defaults have been updated for mpas-ocean and mpas-seaice for 480,120,60,30, and 15km. Files in
/glade/campaign/univ/ucsu0085/inputdata have been updated.