### PR TITLE
Use cesm_postprocessing.sh from CUPID_ROOT

### DIFF
--- a/machines/template.cupid
+++ b/machines/template.cupid
@@ -7,4 +7,5 @@
 source .env_mach_specific.sh
 
 # Run shell script in CUPiD external
-(. {{ SRCROOT }}/tools/CUPiD/helper_scripts/cesm_postprocessing.sh)
+CUPID_ROOT=`./xmlquery --value CUPID_ROOT`
+(. ${CUPID_ROOT}/helper_scripts/cesm_postprocessing.sh)


### PR DESCRIPTION
Users may want to use a version of CUPiD that is different from what is in tools/CUPiD -- they can set CUPID_ROOT to point to that location, and should expect cesm_postprocessing.sh to be launched from that location as part of the workflow

Note that the CESM tag that brings in this PR will also need CUPiD to be update to include https://github.com/NCAR/CUPiD/pull/263 