### PR TITLE
Add missing RRTMGP GPU code

### DIFF
--- a/machines/Depends.nvhpc
+++ b/machines/Depends.nvhpc
@@ -73,7 +73,8 @@ mo_rte_util_array_validation.o \
 mo_rte_util_array.o \
 mo_fluxes_broadband_kernels.o \
 mo_rte_solver_kernels.o \
-mo_optical_props_kernels.o
+mo_optical_props_kernels.o \
+mo_cloud_optics_rrtmgp_kernels.o
 
 CLUBB_OBJS=\
 clubb_intr.o\


### PR DESCRIPTION
In the cam6_4_114 tag (https://github.com/ESCOMP/CAM/pull/1376), the RRTMGP external was upgraded to v1.9.2.

This new RRTMGP tag introduced a new GPU code named `mo_cloud_optics_rrtmgp_kernels.F90` and it should be added to the `Depends.nvhpc` file here to be compiled with the correct GPU flags.