### PR TITLE
moves the primary inputdata server to cisl rda

### DIFF
--- a/config_inputdata.xml
+++ b/config_inputdata.xml
@@ -9,6 +9,11 @@
   <!-- see the file ftp://ftp.cgd.ucar.edu/cesm/inputdata_chksum.dat for proper format. -->
   <server>
     <protocol>wget</protocol>
+    <address>https://osdf-data.gdex.ucar.edu/ncar/gdex/d651077/cesmdata/inputdata/</address>
+  </server>
+
+  <server>
+    <protocol>wget</protocol>
     <address>https://ftp.cgd.ucar.edu/cesm/inputdata/</address>
     <checksum>../inputdata_checksum.dat</checksum>
   </server>


### PR DESCRIPTION
Moves the primary inputdata server from https://ftp.cgd.ucar.edu/cesm/inputdata/
to https://osdf-data.gdex.ucar.edu/ncar/gdex/d651077/cesmdata/inputdata/