### PR TITLE
Update Casper module version and add a missing PUMAS GPU code

### DIFF
--- a/machines/Depends.nvhpc
+++ b/machines/Depends.nvhpc
@@ -47,6 +47,7 @@ micro_mg1_0.o \
 micro_pumas_v1.o \
 micro_pumas_data.o \
 micro_pumas_utils.o \
+pumas_gamma_function.o \
 pumas_stochastic_collect_tau.o \
 micro_pumas_cam.o \
 wv_sat_methods.o \

--- a/machines/casper/config_machines.xml
+++ b/machines/casper/config_machines.xml
@@ -54,10 +54,10 @@
       </modules>
       <modules mpilib="openmpi">
         <command name="load">openmpi/5.0.6</command>
-        <command name="load">netcdf-mpi/4.9.3</command>
+        <command name="load">netcdf-mpi/4.9.2</command>
         <command name="load">parallel-netcdf/1.14.0</command>
-        <command name="load">parallelio/2.6.6</command>
-        <command name="load">esmf/8.8.1</command>
+        <command name="load">parallelio/2.6.5</command>
+        <command name="load">esmf/8.8.0</command>
         <command name="load">ncarcompilers/1.0.0</command>
       </modules>
       <!-- specific settings for MI300A module environment -->


### PR DESCRIPTION
This PR:
- updates the modules on Casper with correct version.
- adds the missing `pumas_gamma_function.F90` code to be compiled with correct GPU flags.