### PR TITLE
Use gfortran v10+ behavior for undefined CMAKE_Fortran_COMPILER_VERSION

### DIFF
--- a/machines/cmake_macros/gnu.cmake
+++ b/machines/cmake_macros/gnu.cmake
@@ -29,6 +29,10 @@ set(SUPPORTS_CXX "TRUE")
 
 message("C compiler version is ${CMAKE_C_COMPILER_VERSION}")
 message("Fortran compiler version is ${CMAKE_Fortran_COMPILER_VERSION}")
+# Note that we use the gfortran 10+ behavior if CMAKE_Fortran_COMPILER_VERSION is
+# undefined. This is needed for the unit test build, where the Macros file is often
+# included before the "project" line (which is the point at which
+# CMAKE_Fortran_COMPILER_VERSION becomes defined).
 if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10 OR NOT DEFINED CMAKE_Fortran_COMPILER_VERSION)
   string(APPEND FFLAGS " -fallow-argument-mismatch  -fallow-invalid-boz ")
   if (DEBUG)


### PR DESCRIPTION
The typical CESM unit test CMake-based builds include CIME_initial_setup.cmake before the `project` line (as is recommended in comments in CIME_initial_setup.cmake). This pulls in the Macros at that point. However, CMAKE_Fortran_COMPILER_VERSION is not defined until after the `project` line. This causes problems on machines that need this logic for gfortran 10+. I have worked around it before by defining FFLAGS unconditionally in the machine-specific cmake file (e.g., gnu_green.cmake), but now that most machines are using gfortran 10+, it seems like the cleaner fix is to use the gfortran 10+ behavior as the default if CMAKE_Fortran_COMPILER_VERSION is not yet defined.

This is needed for the GitHub Actions to pass in https://github.com/ESCOMP/CESM_share/pull/71