### PR TITLE
Change gpu_type to chunk resource on Casper

### DIFF
--- a/machines/casper/config_batch.xml
+++ b/machines/casper/config_batch.xml
@@ -1,16 +1,13 @@
 <!-- casper pbs -->
 <batch_system MACH="casper" type="pbs">
   <batch_submit>qsub</batch_submit>
-  <submit_args>
-    <argument> -l gpu_type=$GPU_TYPE </argument>
-  </submit_args>
   <directives queue="casper" gpu_enabled="true" gpu_type="!mi300a">
     <directive default="/bin/bash" > -S {{ shell }} </directive>
-    <directive> -l select={{ num_nodes }}:ncpus={{ max_cputasks_per_gpu_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}:mem={{ mem_per_node }}GB:ngpus={{ ngpus_per_node }}:mps=1 </directive>
+    <directive> -l select={{ num_nodes }}:ncpus={{ max_cputasks_per_gpu_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}:mem={{ mem_per_node }}GB:ngpus={{ ngpus_per_node }}:gpu_type={{ gpu_type }}:mps=1 </directive>
   </directives>
   <directives queue="casper" gpu_enabled="true" gpu_type="mi300a">
     <directive default="/bin/bash" > -S {{ shell }} </directive>
-    <directive> -l select={{ num_nodes }}:ncpus={{ max_cputasks_per_gpu_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}:mem={{ mem_per_node }}GB:ngpus={{ ngpus_per_node }} </directive>
+    <directive> -l select={{ num_nodes }}:ncpus={{ max_cputasks_per_gpu_node }}:mpiprocs={{ tasks_per_node }}:ompthreads={{ thread_count }}:mem={{ mem_per_node }}GB:ngpus={{ ngpus_per_node }}:gpu_type={{ gpu_type }} </directive>
   </directives>
   <directives queue="casper" gpu_enabled="false">
     <directive default="/bin/bash" > -S {{ shell }} </directive>


### PR DESCRIPTION
This PR moves the `gpu_type` spec from a job-level resource to a chunk-level resource on NSF NCAR's Casper, which is needed to conform to changes made in the November maintenance.

The gpu_type options in CMake could be altered as well (e.g., `a100_80gb` instead of `a100`), but I wanted to keep things minimal here since with this change things will work as is if the rest of the config is kept the same.