### PR TITLE
Set vector length to 1 for debug mode

### DIFF
--- a/machines/casper/gnu_casper.cmake
+++ b/machines/casper/gnu_casper.cmake
@@ -38,6 +38,9 @@ message("OPENACC_GPU_OFFLOAD is ${OPENACC_GPU_OFFLOAD}")
 message("OPENMP_GPU_OFFLOAD is ${OPENMP_GPU_OFFLOAD}")
 
 if (USE_KOKKOS)
+  if (DEBUG)
+    string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
+  endif()
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
   if (KOKKOS_GPU_OFFLOAD)

--- a/machines/casper/intel_casper.cmake
+++ b/machines/casper/intel_casper.cmake
@@ -15,6 +15,9 @@ set(SCXX icpx)
 set(SFC ifort)
 
 if (USE_KOKKOS)
+  if (DEBUG)
+    string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
+  endif()
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
   option(Kokkos_ARCH_ZEN4 "" ON)

--- a/machines/casper/nvhpc_casper.cmake
+++ b/machines/casper/nvhpc_casper.cmake
@@ -27,6 +27,9 @@ message("OPENACC_GPU_OFFLOAD is ${OPENACC_GPU_OFFLOAD}")
 message("OPENMP_GPU_OFFLOAD is ${OPENMP_GPU_OFFLOAD}")
 
 if (USE_KOKKOS)
+  if (DEBUG)
+    string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
+  endif()
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
   if (KOKKOS_GPU_OFFLOAD)

--- a/machines/derecho/gnu_derecho.cmake
+++ b/machines/derecho/gnu_derecho.cmake
@@ -10,6 +10,9 @@ set(SCXX "g++")
 set(SFC "gfortran")
 
 if (USE_KOKKOS)
+  if (DEBUG)
+    string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
+  endif()
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
   if (KOKKOS_GPU_OFFLOAD)

--- a/machines/derecho/intel_derecho.cmake
+++ b/machines/derecho/intel_derecho.cmake
@@ -16,6 +16,9 @@ set(SCXX icpx)
 set(SFC ifort)
 
 if (USE_KOKKOS)
+  if (DEBUG)
+    string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
+  endif()
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
   # Enable EPYC arch in kokkos

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -13,6 +13,9 @@ message("OPENACC_GPU_OFFLOAD is ${OPENACC_GPU_OFFLOAD}")
 message("OPENMP_GPU_OFFLOAD is ${OPENMP_GPU_OFFLOAD}")
 
 if (USE_KOKKOS)
+  if (DEBUG)
+    string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
+  endif()
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
   if (KOKKOS_GPU_OFFLOAD)


### PR DESCRIPTION
This pull request fixes a runtime error of running kokkos dycore in StormSPEED CAM (https://github.com/NCAR/StormSPEED/issues/15), where the HOMMEXX vector length should be set to 1 in a DEBUG build.