### PR TITLE
Fix vectorization optimization options for HB PBL scheme in CAM

### DIFF
--- a/machines/Depends.intel
+++ b/machines/Depends.intel
@@ -68,4 +68,4 @@ $(RRTMGP_OBJS): %.o: %.F90
 # Manually overriding default vectorization threshold due to use of deferred length arrays
 # in Holtslag-Boville Boundary Layer scheme.
 $(HB_DIFF): %.o: %.F90
-  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(CONTIGUOUS_FLAG) -vec-threshold80 $<
+	$(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(CONTIGUOUS_FLAG) -vec-threshold80 $<


### PR DESCRIPTION
Original changes by @mwaxmonsky

This change to `ccs_config` adds some optimization options (`-vec-threshold80`) for the HB PBL scheme in CAM. 

I was only able to test `Depends.intel` on Derecho Intel, but the original changes were on `Depends.intel-oneapi`, but I wasn't able to test that. If there is a way to test the changes on the oneapi file, it would be great to add the same changes to that file as well. Thanks.