### PR TITLE
visualCaseGen: User-specified Grids

### DIFF
--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -660,5 +660,5 @@
     <lon>0.0</lon>
     <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
   </domain>
-  
+
 </domains>

--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -660,10 +660,4 @@
     <lon>0.0</lon>
     <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
   </domain>
-  <domain name="USER_OCN_GRID">
-    <nx>1</nx>
-    <ny>1</ny>
-    <mesh>InvalidPath</mesh>
-    <desc>This grid must be specified using xml variables in the case</desc>
-  </domain>
 </domains>

--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -660,5 +660,10 @@
     <lon>0.0</lon>
     <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
   </domain>
-
+  <domain name="USER_OCN_GRID">
+    <nx>1</nx>
+    <ny>1</ny>
+    <mesh>InvalidPath</mesh>
+    <desc>This grid must be specified using xml variables in the case</desc>
+  </domain>
 </domains>

--- a/component_grids_nuopc.xml
+++ b/component_grids_nuopc.xml
@@ -660,4 +660,5 @@
     <lon>0.0</lon>
     <desc>1x1 Urban C Alpha Test Case -- only valid for DATM/CLM compset</desc>
   </domain>
+  
 </domains>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1751,7 +1751,16 @@
     <grid name="wav">ww3a</grid>
   </model_grid>
 
-  <!-- The following grid is only used for visualCaseGen. Specify grids through xml variables -->
+  <!-- The following grid can be used if the user specifies grids through xml changes in the case directory.
+  This was initially created for visualCaseGen version 1.0, please see visualCaseGen/custom_widget_types/case_creator.py::update_grids_via_xmlchange for how it was done initially.
+  See below for an example of xmlchanges for a custom regional ocean case with compset 1850_DATM%NYF_SLND_SICE_MOM6%REGIONAL_SROF_SGLC_SWAV:
+  ./xmlchange OCN_DOMAIN_MESH=/glade/u/home/manishrv/scratch/croc_input/vcg.xml.4/ocnice/ESMF_mesh_panama1_5b36e8.nc 
+  ./xmlchange ICE_DOMAIN_MESH=/glade/u/home/manishrv/scratch/croc_input/vcg.xml.4/ocnice/ESMF_mesh_panama1_5b36e8.nc 
+  ./xmlchange MASK_MESH=/glade/u/home/manishrv/scratch/croc_input/vcg.xml.4/ocnice/ESMF_mesh_panama1_5b36e8.nc 
+  ./xmlchange ATM_GRID=T62
+  ./xmlchange LND_GRID=T62
+  ./xmlchange ATM_DOMAIN_MESH=/glade/campaign/cesm/cesmdata/inputdata/share/meshes/T62_040121_ESMFmesh.nc
+  ./xmlchange LND_DOMAIN_MESH=/glade/campaign/cesm/cesmdata/inputdata/share/meshes/T62_040121_ESMFmesh.nc  -->
   <model_grid alias="USER_RES">
   </model_grid>
 </grids>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1750,8 +1750,8 @@
   <model_grid alias="ww3a" compset="_WW3|DWAV">
     <grid name="wav">ww3a</grid>
   </model_grid>
-  <!-- The following grid is only used for visualCaseGen -->
+
+  <!-- The following grid is only used for visualCaseGen. Specify grids through xml variables -->
   <model_grid alias="USER_RES">
-    <grid name="ocnice">USER_OCN_GRID</grid>
   </model_grid>
 </grids>

--- a/modelgrid_aliases_nuopc.xml
+++ b/modelgrid_aliases_nuopc.xml
@@ -1750,5 +1750,8 @@
   <model_grid alias="ww3a" compset="_WW3|DWAV">
     <grid name="wav">ww3a</grid>
   </model_grid>
-
+  <!-- The following grid is only used for visualCaseGen -->
+  <model_grid alias="USER_RES">
+    <grid name="ocnice">USER_OCN_GRID</grid>
+  </model_grid>
 </grids>


### PR DESCRIPTION
Details:

visualCaseGen has a new option to specify grids with xml variables in the case directory, and we need a temporary grid to create the grid with. This is used with CROCODILE/CrocoDash so that we can share a CESM sandbox (Because CrocoDash generates regional grids that would otherwise need to be added to ccs_config).

Changes:

1. New grid called USER_RES