### PR TITLE
[WIP] NVIDIA/OpenACC hackathon May 2026 work

### DIFF
--- a/machines/Depends.nvhpc-prof
+++ b/machines/Depends.nvhpc-prof
@@ -2,6 +2,10 @@
 # 04/05/2023 do not apply optimization flags to "SHR_RANDNUM_C_OBJS" for the nvhpc compiler, which will fail the ensemble consistency test
 #
 # Apply a different optimization level consistent with the Intel compiler
+#
+# A compiler for nvhpc with profiling
+# Currently this fails on the link step with undefined references for gptl library calls.
+#
 PERFOBJS=\
 prim_advection_mod.o \
 edge_mod.o \

--- a/machines/Depends.nvhpc-prof
+++ b/machines/Depends.nvhpc-prof
@@ -4,7 +4,6 @@
 # Apply a different optimization level consistent with the Intel compiler
 #
 # A compiler for nvhpc with profiling
-# Currently this fails on the link step with undefined references for gptl library calls.
 #
 PERFOBJS=\
 prim_advection_mod.o \

--- a/machines/Depends.nvhpc-prof
+++ b/machines/Depends.nvhpc-prof
@@ -1,0 +1,192 @@
+# 10/13/2022 nvhpc compiler on gust.hpc.ucar.edu produced incorrect mpitask cound when esm.F90 was optimized
+# 04/05/2023 do not apply optimization flags to "SHR_RANDNUM_C_OBJS" for the nvhpc compiler, which will fail the ensemble consistency test
+#
+# Apply a different optimization level consistent with the Intel compiler
+PERFOBJS=\
+prim_advection_mod.o \
+edge_mod.o \
+derivative_mod.o \
+bndry_mod.o \
+prim_advance_mod.o
+
+REDUCED_OPT_OBJS=\
+SatellitePhenologyMod.o \
+esm.o
+
+REDUCED_ERRORCHKS_IN_DEBUG=\
+fvm_consistent_se_cslam.o \
+clm_instMod.o \
+mpp.o \
+horiz_interp_conserve.o \
+data_override.o \
+MOM_io_infra.o \
+dynColumnStateUpdaterMod.o \
+prim_advection_mod.o \
+MARBL_forcing_mod.o \
+MOM_internal_tide_input.o \
+MOM_ice_shelf.o \
+mom_surface_forcing_nuopc.o
+
+REDUCED_PRECISION_OBJS=\
+shr_wv_sat_mod.o
+
+SHR_RANDNUM_FORT_OBJS=\
+kissvec_mod.o \
+mersennetwister_mod.o \
+dSFMT_interface.o \
+shr_RandNum_mod.o
+
+SHR_RANDNUM_C_OBJS=\
+dSFMT.o \
+dSFMT_utils.o \
+kissvec.o
+
+# Apply GPU flags to the following code
+PUMAS_OBJS=\
+micro_mg1_0.o \
+micro_pumas_v1.o \
+micro_pumas_data.o \
+micro_pumas_utils.o \
+pumas_gamma_function.o \
+pumas_stochastic_collect_tau.o \
+micro_pumas_cam.o \
+wv_sat_methods.o \
+wv_saturation.o \
+macrop_driver.o \
+shr_spfn_mod.o
+
+RRTMGP_OBJS=\
+rrtmgp_lw_rte.o \
+rrtmgp_sw_rte.o \
+rrtmgp_lw_gas_optics.o \
+rrtmgp_sw_gas_optics.o \
+rrtmgp_allsky.o \
+rrtmgp_rfmip_lw.o \
+rrtmgp_rfmip_sw.o \
+mo_fluxes_byband.o \
+mo_zenith_angle_spherical_correction.o \
+mo_rrtmgp_clr_all_sky.o \
+mo_gas_concentrations.o \
+mo_aerosol_optics_rrtmgp_merra.o \
+mo_cloud_optics_rrtmgp.o \
+mo_gas_optics_rrtmgp.o \
+mo_gas_optics_rrtmgp_kernels.o \
+mo_rte_lw.o \
+mo_rte_sw.o \
+mo_rte_util_array_validation.o \
+mo_rte_util_array.o \
+mo_fluxes_broadband_kernels.o \
+mo_rte_solver_kernels.o \
+mo_optical_props_kernels.o \
+mo_cloud_optics_rrtmgp_kernels.o
+
+CLUBB_OBJS=\
+clubb_intr.o\
+adg1_adg2_3d_luhar_pdf.o\
+advance_clubb_core_module.o\
+advance_helper_module.o\
+advance_windm_edsclrm_module.o\
+advance_wp2_wp3_module.o\
+advance_xm_wpxp_module.o\
+advance_xp2_xpyp_module.o\
+advance_xp3_module.o\
+array_index.o\
+calc_pressure.o\
+calc_roots.o\
+calendar.o\
+clip_explicit.o\
+clip_semi_implicit.o\
+clubb_api_module.o\
+clubb_precision.o\
+code_timer_module.o\
+constants_clubb.o\
+corr_varnce_module.o\
+diagnose_correlations_module.o\
+diffusion.o\
+endian.o\
+error_code.o\
+file_functions.o\
+fill_holes.o\
+grid_class.o\
+hydromet_pdf_parameter_module.o\
+index_mapping.o\
+input_names.o\
+input_reader.o\
+interpolation.o\
+lapack_interfaces.o\
+lapack_wrap.o\
+LY93_pdf.o\
+matrix_operations.o\
+matrix_solver_wrapper.o\
+mean_adv.o\
+mixing_length.o\
+model_flags.o\
+mono_flux_limiter.o\
+mt95.o\
+Nc_Ncn_eqns.o\
+new_hybrid_pdf.o\
+new_hybrid_pdf_main.o\
+new_pdf.o\
+new_pdf_main.o\
+new_tsdadg_pdf.o\
+numerical_check.o\
+output_grads.o\
+output_netcdf.o\
+parameter_indices.o\
+parameters_model.o\
+parameters_tunable.o\
+pdf_closure_module.o\
+pdf_parameter_module.o\
+pdf_utilities.o\
+penta_lu_solver.o\
+pos_definite_module.o\
+precipitation_fraction.o\
+saturation.o\
+setup_clubb_pdf_params.o\
+sfc_varnce_module.o\
+sigma_sqd_w_module.o\
+Skx_module.o\
+sponge_layer_damping.o\
+stat_file_module.o\
+stats_clubb_utilities.o\
+stats_lh_sfc_module.o\
+stats_lh_zt_module.o\
+stats_rad_zm_module.o\
+stats_rad_zt_module.o\
+stats_sfc_module.o\
+stats_type.o\
+stats_type_utilities.o\
+stats_variables.o\
+stats_zm_module.o\
+stats_zt_module.o\
+T_in_K_module.o\
+tridiag_lu_solver.o\
+turbulent_adv_pdf.o
+
+ifeq ($(DEBUG),FALSE)
+  $(PERFOBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -Mfprelaxed=div $<
+  $(REDUCED_OPT_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O1 $<
+  $(REDUCED_PRECISION_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -fast $<
+  $(SHR_RANDNUM_FORT_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -fast -Mfprelaxed=div,sqrt $<
+#  $(SHR_RANDNUM_C_OBJS): %.o: %.c
+#	  $(CC) -c $(INCLDIR) $(INCS) $(CFLAGS) -O3 -fast $<
+  $(PUMAS_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -O3 -fastsse -Mnofma -Mflushz -Mfprelaxed=sqrt $(OPENACC_GPU_FLAGS) $<
+  $(RRTMGP_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(OPENACC_GPU_FLAGS) $<
+  $(CLUBB_OBJS): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) $(OPENACC_GPU_FLAGS) $<
+
+ifeq ($(COMP_NAME),mpaso)
+  # mpas ocean files need gpuflags
+  FFLAGS +=$(GPUFLAGS)
+endif
+
+else
+  $(REDUCED_ERRORCHKS_IN_DEBUG): %.o: %.F90
+	  $(FC) -c $(INCLDIR) $(INCS) $(FFLAGS) $(FREEFLAGS) -Mnobounds -Ktrap=none -Knoieee $<
+endif

--- a/machines/cmake_macros/nvhpc-prof.cmake
+++ b/machines/cmake_macros/nvhpc-prof.cmake
@@ -1,0 +1,119 @@
+# -gopt Generate debug information without disabling optimizations
+# -time Generate timing information for each compilation phase
+string(APPEND CFLAGS " -gopt  -time")
+
+if(compile_threaded)
+  string(APPEND CFLAGS " -mp")
+endif()
+
+# -Mnofma turns off Fused Multiply-Add (FMA) instructions
+if(NOT DEBUG)
+  string(APPEND CFLAGS " -O -Mnofma")
+  string(APPEND CXXFLAGS " -O2 -Mnofma")
+  string(APPEND FFLAGS " -O -Mnofma")
+else()
+  # -Kieee use IEEE division and enbale trps
+  # -Ktrap=fp Floating point trapping for invalid, division by zero, and overflow
+  # -Wall turns on most of the compiler warnings
+  string(APPEND CFLAGS " -O0 -Mnofma -g -Wall -Kieee -traceback")
+  string(APPEND CXXFLAGS " -O0 -Mnofma -g -Wall -Kieee -traceback")
+
+  # -MBounds check array bounds
+  string(APPEND FFLAGS " -O0 -g -Ktrap=fp -Mbounds -Kieee")
+endif()
+
+string(APPEND CFLAGS " -Mnofma")
+string(APPEND FFLAGS " -Mnofma")
+
+string(APPEND CPPDEFS " -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRNVIDIA -DNO_QUAD_PRECISION -DCPRPGI")
+
+set(CXX_LINKER "CXX")
+set(FC_AUTO_R8 "-r8")
+
+# -Mflushz does flush-to-zero for floating pointer operations
+string(APPEND FFLAGS " -i4 -gopt -time -Mextend -byteswapio -Mflushz -Kieee")
+string(APPEND CXXFLAGS " -Mflushz -Kieee")
+
+# -Mnovect turn off vectorization for the CDEPS models
+if(COMP_NAME IN_LIST "datm;dlnd;drof;dwav;dice;docn")
+  string(APPEND FFLAGS " -Mnovect")
+endif()
+
+set(FFLAGS_NOOPT "-O0")
+set(FIXEDFLAGS "-Mfixed")
+set(FREEFLAGS "-Mfree")
+set(HAS_F2008_CONTIGUOUS "FALSE")
+set(LDFLAGS "-time -Wl,--allow-multiple-definition")
+
+if(compile_threaded)
+  string(APPEND CFLAGS " -mp")
+  string(APPEND CXXFLAGS " -mp")
+  string(APPEND FFLAGS " -mp")
+  string(APPEND LDFLAGS " -mp")
+endif()
+
+set(MPICC "mpicc")
+set(MPICXX "mpicxx")
+set(MPIFC "mpif90")
+set(SCC "nvc")
+set(SCXX "nvc++")
+set(SFC "nvfortran")
+
+if(COMP_NAME STREQUAL mpi-serial)
+  string(APPEND CFLAGS " -std=gnu89")
+  string(APPEND CXXFLAGS " -std=c++17")
+else()
+  string(APPEND CFLAGS " -std=gnu99")
+  string(APPEND CXXFLAGS " -std=c++17")
+endif()
+
+set(OPENACC_GPU_FLAGS " -noacc ")
+set(OPENMP_GPU_FLAGS "")
+
+if(GPU_TYPE STREQUAL v100)
+  if(OPENACC_GPU_OFFLOAD)
+    set(OPENACC_GPU_FLAGS " -acc -gpu=cc70,lineinfo,nofma -Minfo=accel ")
+  endif()
+
+  if(OPENMP_GPU_OFFLOAD)
+    set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc70,lineinfo,nofma -Minfo=accel ")
+  endif()
+endif()
+
+if(GPU_TYPE STREQUAL a100)
+  if(OPENACC_GPU_OFFLOAD)
+    set(OPENACC_GPU_FLAGS " -acc -gpu=cc80,lineinfo,nofma -Minfo=accel ")
+  endif()
+
+  if(OPENMP_GPU_OFFLOAD)
+    set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc80,lineinfo,nofma -Minfo=accel ")
+  endif()
+endif()
+
+if(GPU_TYPE STREQUAL a10 OR GPU_TYPE STREQUAL a2)
+  if(OPENACC_GPU_OFFLOAD)
+    set(OPENACC_GPU_FLAGS " -acc -gpu=cc86,lineinfo,nofma -Minfo=accel ")
+  endif()
+
+  if(OPENMP_GPU_OFFLOAD)
+    set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc86,lineinfo,nofma -Minfo=accel ")
+  endif()
+endif()
+
+if(GPU_TYPE STREQUAL h100)
+  if(OPENACC_GPU_OFFLOAD)
+    set(OPENACC_GPU_FLAGS " -acc -gpu=cc90,lineinfo,nofma -Minfo=accel ")
+  endif()
+
+  if(OPENMP_GPU_OFFLOAD)
+    set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc90,lineinfo,nofma -Minfo=accel ")
+  endif()
+endif()
+
+if(OPENACC_GPU_FLAGS)
+  string(APPEND LDFLAGS " ${OPENACC_GPU_FLAGS}")
+endif()
+
+if(OPENMP_GPU_FLAGS)
+  string(APPEND LDFLAGS " ${OPENMP_GPU_FLAGS}")
+endif()

--- a/machines/cmake_macros/nvhpc-prof.cmake
+++ b/machines/cmake_macros/nvhpc-prof.cmake
@@ -1,6 +1,6 @@
 # -gopt Generate debug information without disabling optimizations
 # -time Generate timing information for each compilation phase
-string(APPEND CFLAGS " -gopt  -time")
+string(APPEND CFLAGS " -gopt")
 
 if(compile_threaded)
   string(APPEND CFLAGS " -mp")

--- a/machines/cmake_macros/nvhpc-prof.cmake
+++ b/machines/cmake_macros/nvhpc-prof.cmake
@@ -31,7 +31,7 @@ set(CXX_LINKER "CXX")
 set(FC_AUTO_R8 "-r8")
 
 # -Mflushz does flush-to-zero for floating pointer operations
-string(APPEND FFLAGS " -i4 -gopt -time -Mextend -byteswapio -Mflushz -Kieee")
+string(APPEND FFLAGS " -i4 -gopt -Mextend -byteswapio -Mflushz -Kieee")
 string(APPEND CXXFLAGS " -Mflushz -Kieee")
 
 # -Mnovect turn off vectorization for the CDEPS models
@@ -43,7 +43,7 @@ set(FFLAGS_NOOPT "-O0")
 set(FIXEDFLAGS "-Mfixed")
 set(FREEFLAGS "-Mfree")
 set(HAS_F2008_CONTIGUOUS "FALSE")
-set(LDFLAGS "-time -Wl,--allow-multiple-definition")
+set(LDFLAGS "-Wl,--allow-multiple-definition")
 
 if(compile_threaded)
   string(APPEND CFLAGS " -mp")

--- a/machines/cmake_macros/nvhpc.cmake
+++ b/machines/cmake_macros/nvhpc.cmake
@@ -1,15 +1,24 @@
+# -gopt Generate debug information without disabling optimizations
+# -time Generate timing information for each compilation phase
 string(APPEND CFLAGS " -gopt  -time")
-if (compile_threaded)
+
+if(compile_threaded)
   string(APPEND CFLAGS " -mp")
 endif()
 
-if (NOT DEBUG)
+# -Mnofma turns off Fused Multiply-Add (FMA) instructions
+if(NOT DEBUG)
   string(APPEND CFLAGS " -O -Mnofma")
   string(APPEND CXXFLAGS " -O2 -Mnofma")
   string(APPEND FFLAGS " -O -Mnofma")
 else()
+  # -Kieee use IEEE division and enbale trps
+  # -Ktrap=fp Floating point trapping for invalid, division by zero, and overflow
+  # -Wall turns on most of the compiler warnings
   string(APPEND CFLAGS " -O0 -Mnofma -g -Wall -Kieee -traceback")
   string(APPEND CXXFLAGS " -O0 -Mnofma -g -Wall -Kieee -traceback")
+
+  # -MBounds check array bounds
   string(APPEND FFLAGS " -O0 -g -Ktrap=fp -Mbounds -Kieee")
 endif()
 
@@ -20,22 +29,29 @@ string(APPEND CPPDEFS " -DFORTRANUNDERSCORE -DNO_SHR_VMATH -DNO_R16 -DCPRNVIDIA 
 
 set(CXX_LINKER "CXX")
 set(FC_AUTO_R8 "-r8")
+
+# -Mflushz does flush-to-zero for floating pointer operations
 string(APPEND FFLAGS " -i4 -gopt -time -Mextend -byteswapio -Mflushz -Kieee")
 string(APPEND CXXFLAGS " -Mflushz -Kieee")
-if (COMP_NAME IN_LIST "datm;dlnd;drof;dwav;dice;docn")
+
+# -Mnovect turn off vectorization for the CDEPS models
+if(COMP_NAME IN_LIST "datm;dlnd;drof;dwav;dice;docn")
   string(APPEND FFLAGS " -Mnovect")
 endif()
+
 set(FFLAGS_NOOPT "-O0")
 set(FIXEDFLAGS "-Mfixed")
 set(FREEFLAGS "-Mfree")
 set(HAS_F2008_CONTIGUOUS "FALSE")
 set(LDFLAGS "-time -Wl,--allow-multiple-definition")
-if (compile_threaded)
+
+if(compile_threaded)
   string(APPEND CFLAGS " -mp")
   string(APPEND CXXFLAGS " -mp")
   string(APPEND FFLAGS " -mp")
   string(APPEND LDFLAGS " -mp")
 endif()
+
 set(MPICC "mpicc")
 set(MPICXX "mpicxx")
 set(MPIFC "mpif90")
@@ -43,7 +59,7 @@ set(SCC "nvc")
 set(SCXX "nvc++")
 set(SFC "nvfortran")
 
-if (COMP_NAME STREQUAL mpi-serial)
+if(COMP_NAME STREQUAL mpi-serial)
   string(APPEND CFLAGS " -std=gnu89")
   string(APPEND CXXFLAGS " -std=c++17")
 else()
@@ -53,41 +69,51 @@ endif()
 
 set(OPENACC_GPU_FLAGS " -noacc ")
 set(OPENMP_GPU_FLAGS "")
-if (GPU_TYPE STREQUAL v100)
-  if (OPENACC_GPU_OFFLOAD)
+
+if(GPU_TYPE STREQUAL v100)
+  if(OPENACC_GPU_OFFLOAD)
     set(OPENACC_GPU_FLAGS " -acc -gpu=cc70,lineinfo,nofma -Minfo=accel ")
   endif()
-  if (OPENMP_GPU_OFFLOAD)
+
+  if(OPENMP_GPU_OFFLOAD)
     set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc70,lineinfo,nofma -Minfo=accel ")
   endif()
 endif()
-if (GPU_TYPE STREQUAL a100)
-  if (OPENACC_GPU_OFFLOAD)
+
+if(GPU_TYPE STREQUAL a100)
+  if(OPENACC_GPU_OFFLOAD)
     set(OPENACC_GPU_FLAGS " -acc -gpu=cc80,lineinfo,nofma -Minfo=accel ")
   endif()
-  if (OPENMP_GPU_OFFLOAD)
+
+  if(OPENMP_GPU_OFFLOAD)
     set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc80,lineinfo,nofma -Minfo=accel ")
   endif()
 endif()
-if (GPU_TYPE STREQUAL a10 OR GPU_TYPE STREQUAL a2)
-  if (OPENACC_GPU_OFFLOAD)
+
+if(GPU_TYPE STREQUAL a10 OR GPU_TYPE STREQUAL a2)
+  if(OPENACC_GPU_OFFLOAD)
     set(OPENACC_GPU_FLAGS " -acc -gpu=cc86,lineinfo,nofma -Minfo=accel ")
   endif()
-  if (OPENMP_GPU_OFFLOAD)
+
+  if(OPENMP_GPU_OFFLOAD)
     set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc86,lineinfo,nofma -Minfo=accel ")
   endif()
 endif()
-if (GPU_TYPE STREQUAL h100)
-  if (OPENACC_GPU_OFFLOAD)
+
+if(GPU_TYPE STREQUAL h100)
+  if(OPENACC_GPU_OFFLOAD)
     set(OPENACC_GPU_FLAGS " -acc -gpu=cc90,lineinfo,nofma -Minfo=accel ")
   endif()
-  if (OPENMP_GPU_OFFLOAD)
+
+  if(OPENMP_GPU_OFFLOAD)
     set(OPENMP_GPU_FLAGS " -mp=gpu -gpu=cc90,lineinfo,nofma -Minfo=accel ")
   endif()
 endif()
-if (OPENACC_GPU_FLAGS)
+
+if(OPENACC_GPU_FLAGS)
   string(APPEND LDFLAGS " ${OPENACC_GPU_FLAGS}")
 endif()
-if (OPENMP_GPU_FLAGS)
+
+if(OPENMP_GPU_FLAGS)
   string(APPEND LDFLAGS " ${OPENMP_GPU_FLAGS}")
 endif()

--- a/machines/cmake_macros/nvhpc.cmake
+++ b/machines/cmake_macros/nvhpc.cmake
@@ -1,6 +1,6 @@
 # -gopt Generate debug information without disabling optimizations
 # -time Generate timing information for each compilation phase
-string(APPEND CFLAGS " -gopt  -time")
+string(APPEND CFLAGS " -gopt")
 
 if(compile_threaded)
   string(APPEND CFLAGS " -mp")

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -36,8 +36,8 @@
         <arg name="separator"> -- </arg>
       </arguments>
     </mpirun>
-    <!-- Run through the profiler for nvhpc -->
-    <mpirun mpilib="default" compiler="nvhpc">
+    <!-- Run through the NVIDIA profiler for nvhpc only for non-DEBUG builds-->
+    <mpirun mpilib="default" compiler="nvhpc" DEBUG="FALSE">
       <executable>nsys profile --cpuctxsw=process-tree mpibind</executable>
       <arguments>
         <arg name="label"> --label</arg>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -38,7 +38,7 @@
     </mpirun>
     <!-- Run through the NVIDIA profiler for nvhpc only for non-DEBUG builds-->
     <mpirun mpilib="default" compiler="nvhpc" DEBUG="FALSE">
-      <executable>nsys profile --cpuctxsw=process-tree mpibind</executable>
+      <executable>nsys profile --trace nvtx --cpuctxsw=process-tree mpibind</executable>
       <arguments>
         <arg name="label"> --label</arg>
         <arg name="buffer"> --line-buffer</arg>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -38,6 +38,7 @@
     </mpirun>
     <!-- Run through the profiler for nvhpc -->
     <mpirun mpilib="default" compiler="nvhpc">
+      <!-- nsys seems to be the GPU profiler and not for CPU's, so this needs to change to a different one -->
       <executable>nsys profile mpibind</executable>
       <arguments>
         <arg name="label"> --label</arg>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -1,7 +1,7 @@
 <machine MACH="derecho">
     <DESC>NCAR AMD EPYC system</DESC>
     <OS>CNL</OS>
-    <COMPILERS>intel,gnu,nvhpc,cray</COMPILERS>
+    <COMPILERS>intel,gnu,nvhpc,nvhpc-prof,cray</COMPILERS>
     <MPILIBS>mpich,openmpi</MPILIBS>
     <CIME_OUTPUT_ROOT>$ENV{SCRATCH}</CIME_OUTPUT_ROOT>
     <DIN_LOC_ROOT>$ENV{CESMDATAROOT}/inputdata</DIN_LOC_ROOT>
@@ -27,7 +27,15 @@
         <arg name="buffer"> --line-buffer</arg>
         <arg name="separator"> -- </arg>
       </arguments>
-   </mpirun>
+    </mpirun>
+    <mpirun mpilib="default" compiler="nvhpc-prof">
+      <executable>nsys profile mpibind</executable>
+      <arguments>
+        <arg name="label"> --label</arg>
+        <arg name="buffer"> --line-buffer</arg>
+        <arg name="separator"> -- </arg>
+      </arguments>
+    </mpirun>
     <module_system type="module" allow_error="true">
       <init_path lang="perl">$ENV{LMOD_ROOT}/lmod/init/perl</init_path>
       <init_path lang="python">$ENV{LMOD_ROOT}/lmod/init/env_modules_python.py</init_path>
@@ -63,6 +71,10 @@
         <command name="load">nvhpc/25.9</command>
         <command name="load">cray-libsci/25.03.0</command>
       </modules>
+      <modules compiler="nvhpc-prof">
+        <command name="load">nvhpc/25.9</command>
+        <command name="load">cray-libsci/25.03.0</command>
+      </modules>
       <modules>
         <command name="load">ncarcompilers/1.2.0</command>
       </modules>
@@ -74,6 +86,9 @@
         <command name="load">cray-mpich/8.1.32</command>
       </modules>
       <modules mpilib="mpich" compiler="nvhpc" gpu_type="!none">
+        <command name="load">cuda/12.9</command>
+      </modules>
+      <modules mpilib="mpich" compiler="nvhpc-prof" gpu_type="!none">
         <command name="load">cuda/12.9</command>
       </modules>
       <modules mpilib="mpich" compiler="gnu" gpu_type="!none">

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -36,6 +36,15 @@
         <arg name="separator"> -- </arg>
       </arguments>
     </mpirun>
+    <!-- Run through the profiler for nvhpc -->
+    <mpirun mpilib="default" compiler="nvhpc">
+      <executable>nsys profile mpibind</executable>
+      <arguments>
+        <arg name="label"> --label</arg>
+        <arg name="buffer"> --line-buffer</arg>
+        <arg name="separator"> -- </arg>
+      </arguments>
+    </mpirun>
     <module_system type="module" allow_error="true">
       <init_path lang="perl">$ENV{LMOD_ROOT}/lmod/init/perl</init_path>
       <init_path lang="python">$ENV{LMOD_ROOT}/lmod/init/env_modules_python.py</init_path>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -29,7 +29,7 @@
       </arguments>
     </mpirun>
     <mpirun mpilib="default" compiler="nvhpc-prof">
-      <executable>nsys profile mpibind</executable>
+      <executable>nsys profile --cpuctxsw=process-tree mpibind</executable>
       <arguments>
         <arg name="label"> --label</arg>
         <arg name="buffer"> --line-buffer</arg>
@@ -38,8 +38,7 @@
     </mpirun>
     <!-- Run through the profiler for nvhpc -->
     <mpirun mpilib="default" compiler="nvhpc">
-      <!-- nsys seems to be the GPU profiler and not for CPU's, so this needs to change to a different one -->
-      <executable>nsys profile mpibind</executable>
+      <executable>nsys profile --cpuctxsw=process-tree mpibind</executable>
       <arguments>
         <arg name="label"> --label</arg>
         <arg name="buffer"> --line-buffer</arg>

--- a/machines/derecho/config_machines.xml
+++ b/machines/derecho/config_machines.xml
@@ -28,16 +28,9 @@
         <arg name="separator"> -- </arg>
       </arguments>
     </mpirun>
+    <!-- the nvhpc-prof compiler is for running CESM through the nvhpc profiler nsys -->
+    <!-- Run through the NVIDIA profiler for nvhpc-prof only for non-DEBUG builds-->
     <mpirun mpilib="default" compiler="nvhpc-prof">
-      <executable>nsys profile --cpuctxsw=process-tree mpibind</executable>
-      <arguments>
-        <arg name="label"> --label</arg>
-        <arg name="buffer"> --line-buffer</arg>
-        <arg name="separator"> -- </arg>
-      </arguments>
-    </mpirun>
-    <!-- Run through the NVIDIA profiler for nvhpc only for non-DEBUG builds-->
-    <mpirun mpilib="default" compiler="nvhpc" DEBUG="FALSE">
       <executable>nsys profile --trace nvtx --cpuctxsw=process-tree mpibind</executable>
       <arguments>
         <arg name="label"> --label</arg>

--- a/machines/derecho/gnu_derecho.cmake
+++ b/machines/derecho/gnu_derecho.cmake
@@ -1,7 +1,9 @@
 string(APPEND CONFIG_ARGS " --host=cray")
-if (COMP_NAME STREQUAL gptl)
+
+if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
 endif()
+
 set(MPICC "cc")
 set(MPICXX "CC")
 set(MPIFC "ftn")
@@ -9,30 +11,39 @@ set(SCC "gcc")
 set(SCXX "g++")
 set(SFC "gfortran")
 
-if (USE_KOKKOS)
-  if (DEBUG)
+# fopt-info-vec give optimization Information around vectorization
+# fopt-info-vec-missed give optimization Information around vectorization loops that were not vectorized and the reason why
+string(APPEND FFLAGS "  -fopt-info-vec -fopt-info-vec-missed")
+
+if(USE_KOKKOS)
+  if(DEBUG)
     string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
   endif()
+
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
-  if (KOKKOS_GPU_OFFLOAD)
+
+  if(KOKKOS_GPU_OFFLOAD)
     string(APPEND CPPDEFS " -DGPU -DTHRUST_IGNORE_CUB_VERSION_CHECK -DHOMMEXX_ENABLE_GPU")
     string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF")
     string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=OFF -DKokkos_ENABLE_AGGRESSIVE_VECTORIZATION=OFF")
     string(APPEND CXXFLAGS " -extended-lambda -Wext-lambda-captures-this -std=c++17 -arch=sm_80")
   else()
     # Enable EPYC arch in kokkos
-    if (compile_threaded)
+    if(compile_threaded)
       # Settings used when OpenMP is the Kokkos backend
       string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_ZEN3=ON -DKokkos_ENABLE_AGGRESSIVE_VECTORIZATION=ON -DKokkos_ENABLE_SERIAL=OFF -DKokkos_ENABLE_OPENMP=ON")
     else()
       string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_ZEN3=ON -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=OFF")
     endif()
+
     string(APPEND CXXFLAGS " -march=znver3 -mtune=znver3")
   endif()
-  if (CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
-    set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch"  CACHE STRING "" FORCE) # only works with gnu v10 and above
+
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_GREATER_EQUAL 10)
+    set(CMAKE_Fortran_FLAGS "-fallow-argument-mismatch" CACHE STRING "" FORCE) # only works with gnu v10 and above
   endif()
+
   string(APPEND LDFLAGS " -lstdc++ ")
   string(APPEND SLIBS " -lsci_gnu -lkokkoscontainers -lkokkoscore -lkokkossimd ")
 endif()

--- a/machines/derecho/intel_derecho.cmake
+++ b/machines/derecho/intel_derecho.cmake
@@ -1,39 +1,50 @@
 set(CONFIG_ARGS "--host=cray")
 string(APPEND CFLAGS " -qopt-report -march=core-avx2")
 string(APPEND CXXFLAGS " -qopt-report -march=core-avx2")
-string(APPEND FFLAGS " -qopt-report -march=core-avx2 -Qoption,fpp,-macro_expand=vc")
-if (COMP_NAME STREQUAL gptl)
+
+# qopt-report=3 is optimization report level
+# vec-threshold reports on vectorization
+string(APPEND FFLAGS " -qopt-reporti=3 -vec-threshhold0 -march=core-avx2 -Qoption,fpp,-macro_expand=vc")
+
+-qopt-report=3 -vec-threshold0
+
+if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")
 endif()
-if (COMP_NAME STREQUAL mpi-serial)
+
+if(COMP_NAME STREQUAL mpi-serial)
   string(APPEND CFLAGS " -std=c89 ")
-endif()	
-if (MPILIB STREQUAL mpi-serial AND NOT compile_threaded)
+endif()
+
+if(MPILIB STREQUAL mpi-serial AND NOT compile_threaded)
   set(PFUNIT_PATH "$ENV{CESMDATAROOT}/tools/pFUnit/pFUnit4.8.0_derecho_Intel2023.2.1_noMPI_noOpenMP")
 endif()
+
 set(SCC icx)
 set(SCXX icpx)
 set(SFC ifx)
 
-if (DEBUG)
+if(DEBUG)
   # -check uninit is giving an error in GLIBC as of intel/2025.2.1
   string(APPEND FFLAGS " -check nouninit")
 endif()
 
-
-if (USE_KOKKOS)
-  if (DEBUG)
+if(USE_KOKKOS)
+  if(DEBUG)
     string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
   endif()
+
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
+
   # Enable EPYC arch in kokkos
-  if (compile_threaded)
+  if(compile_threaded)
     # Settings used when OpenMP is the Kokkos backend
     string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_ZEN3=ON -DKokkos_ENABLE_AGGRESSIVE_VECTORIZATION=ON -DKokkos_ENABLE_SERIAL=OFF -DKokkos_ENABLE_OPENMP=ON")
   else()
     string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_ZEN3=ON -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=OFF")
   endif()
+
   set(CMAKE_CXX_FLAGS "-DTHRUST_IGNORE_CUB_VERSION_CHECK" CACHE STRING "" FORCE)
   string(APPEND LDFLAGS " -lstdc++ ")
   string(APPEND SLIBS " -lkokkoscontainers -lkokkoscore -lkokkossimd ")

--- a/machines/derecho/intel_derecho.cmake
+++ b/machines/derecho/intel_derecho.cmake
@@ -6,8 +6,6 @@ string(APPEND CXXFLAGS " -qopt-report -march=core-avx2")
 # vec-threshold reports on vectorization
 string(APPEND FFLAGS " -qopt-reporti=3 -vec-threshhold0 -march=core-avx2 -Qoption,fpp,-macro_expand=vc")
 
--qopt-report=3 -vec-threshold0
-
 if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")
 endif()

--- a/machines/derecho/intel_derecho.cmake
+++ b/machines/derecho/intel_derecho.cmake
@@ -4,7 +4,7 @@ string(APPEND CXXFLAGS " -qopt-report -march=core-avx2")
 
 # qopt-report=3 is optimization report level
 # vec-threshold reports on vectorization
-string(APPEND FFLAGS " -qopt-reporti=3 -vec-threshhold0 -march=core-avx2 -Qoption,fpp,-macro_expand=vc")
+string(APPEND FFLAGS " -qopt-report=3 -vec-threshold0 -march=core-avx2 -Qoption,fpp,-macro_expand=vc")
 
 if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_SLASHPROC")

--- a/machines/derecho/nvhpc-prof_derecho.cmake
+++ b/machines/derecho/nvhpc-prof_derecho.cmake
@@ -1,0 +1,50 @@
+string(APPEND CONFIG_ARGS " --host=cray")
+string(APPEND CPPDEFS " -DHAVE_IEEE_ARITHMETIC")
+
+if(COMP_NAME STREQUAL gptl)
+  string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
+endif()
+
+# These changes increased wallclock for a case from 170 to 4600 seconds
+#string(APPEND FFLAGS " -Minstrument -traceback")
+
+# Add the nvhpc wrap nvtx library for instrumentation to the link step
+string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
+
+if(NOT DEBUG)
+  string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
+  string(APPEND CXXFLAGS " -tp=zen3")
+  string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
+else()
+  # Add information about vectorization to the compiler output
+  string(APPEND FFLAGS " -Minfo=vect -Mneginfo=vect")
+
+  # To output all information about optimization
+  # string(APPEND FFLAGS " Minfo=all -Mneginfo=all")
+endif()
+
+message("GPU_TYPE is ${GPU_TYPE}")
+message("OPENACC_GPU_OFFLOAD is ${OPENACC_GPU_OFFLOAD}")
+message("OPENMP_GPU_OFFLOAD is ${OPENMP_GPU_OFFLOAD}")
+
+if(USE_KOKKOS)
+  if(DEBUG)
+    string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
+  endif()
+
+  # Generic setting that are used regardless of Architecture or Kokkos backend
+  string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
+
+  if(KOKKOS_GPU_OFFLOAD)
+    string(APPEND CPPDEFS " -DGPU -DTHRUST_IGNORE_CUB_VERSION_CHECK -DHOMMEXX_ENABLE_GPU")
+    string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF")
+    string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=OFF -DKokkos_ENABLE_AGGRESSIVE_VECTORIZATION=OFF")
+    string(APPEND CXXFLAGS " -extended-lambda -Wext-lambda-captures-this -std=c++17 -arch=sm_80")
+  else()
+    # Enable EPYC arch in kokkos
+    string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_ZEN3=ON -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=OFF") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
+  endif()
+
+  string(APPEND LDFLAGS " -lstdc++ ")
+  string(APPEND SLIBS " -lsci_nvidia -lkokkoscontainers -lkokkoscore -lkokkossimd ")
+endif()

--- a/machines/derecho/nvhpc-prof_derecho.cmake
+++ b/machines/derecho/nvhpc-prof_derecho.cmake
@@ -1,3 +1,8 @@
+#
+# A compiler for nvhpc with profiling
+# Currently this fails on the link step with undefined references for gptl library calls.
+# So right now this is just a duplicate of the "nvhpc" compiler.
+#
 string(APPEND CONFIG_ARGS " --host=cray")
 string(APPEND CPPDEFS " -DHAVE_IEEE_ARITHMETIC")
 

--- a/machines/derecho/nvhpc-prof_derecho.cmake
+++ b/machines/derecho/nvhpc-prof_derecho.cmake
@@ -1,7 +1,7 @@
 #
 # A compiler for nvhpc with profiling
-# Currently this fails on the link step with undefined references for gptl library calls.
-# So right now this is just a duplicate of the "nvhpc" compiler.
+#
+# Mostly duplicates nvhpc_derecho.cmake, but adds profiling compiler flags and link options
 #
 string(APPEND CONFIG_ARGS " --host=cray")
 string(APPEND CPPDEFS " -DHAVE_IEEE_ARITHMETIC")
@@ -10,22 +10,25 @@ if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
 endif()
 
-# These changes increased wallclock for a case from 170 to 4600 seconds
-#string(APPEND FFLAGS " -Minstrument -traceback")
-
 # Add the nvhpc wrap nvtx library for instrumentation to the link step
 string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
 
 if(NOT DEBUG)
+  # -tp is the target processor
+  # -Mstack_arrays put automatic arrays on the stack
+  # -Mallocatable=O3 use the 2003 standard for allocatable arrays, which allows them to be used in more contexts and with more features than the older Fortran 90/95 standard
   string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
   string(APPEND CXXFLAGS " -tp=zen3")
-  string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
-else()
-  # Add information about vectorization to the compiler output
-  string(APPEND FFLAGS " -Minfo=vect -Mneginfo=vect")
 
-  # To output all information about optimization
-  # string(APPEND FFLAGS " Minfo=all -Mneginfo=all")
+  # -Mnofma turns off Fused Multiply-Add (FMA) instructions at the link step
+  string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
+
+  # Add information about optimization to the compiler output
+  # Will show up at the end of the bld log file
+  string(APPEND FFLAGS " -Minfo=all -Mneginfo=all")
+else()
+  # Add debug information and symbols
+  string(APPEND FFLAGS " -traceback")
 endif()
 
 message("GPU_TYPE is ${GPU_TYPE}")

--- a/machines/derecho/nvhpc-prof_derecho.cmake
+++ b/machines/derecho/nvhpc-prof_derecho.cmake
@@ -17,11 +17,12 @@ if(NOT DEBUG)
   # -tp is the target processor
   # -Mstack_arrays put automatic arrays on the stack
   # -Mallocatable=O3 use the 2003 standard for allocatable arrays, which allows them to be used in more contexts and with more features than the older Fortran 90/95 standard
-  string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
+  # -Minstrument instrument the code subroutines/functions for nvtx profiling
+  string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03 -Minstrument")
   string(APPEND CXXFLAGS " -tp=zen3")
 
   # -Mnofma turns off Fused Multiply-Add (FMA) instructions at the link step
-  string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
+  string(APPEND LDFLAGS " -tp=zen3 -Mnofma -Minstrument")
 
   # Add information about optimization to the compiler output
   # Will show up at the end of the bld log file

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -5,6 +5,9 @@ if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
 endif()
 
+string(APPEND FFLAGS " -Minstrument -traceback")
+string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
+
 if(NOT DEBUG)
   string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
   string(APPEND CXXFLAGS " -tp=zen3")

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -1,24 +1,35 @@
 string(APPEND CONFIG_ARGS " --host=cray")
 string(APPEND CPPDEFS " -DHAVE_IEEE_ARITHMETIC")
-if (COMP_NAME STREQUAL gptl)
+
+if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
 endif()
-if (NOT DEBUG)
+
+if(NOT DEBUG)
   string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
   string(APPEND CXXFLAGS " -tp=zen3")
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
+else()
+  # Add information about vectorization to the compiler output
+  string(APPEND FFLAGS " Minfo=vect and -Mneginfo=vect")
+
+  # To output all information about optimization
+  # string(APPEND FFLAGS " Minfo=all and -Mneginfo=all")
 endif()
+
 message("GPU_TYPE is ${GPU_TYPE}")
 message("OPENACC_GPU_OFFLOAD is ${OPENACC_GPU_OFFLOAD}")
 message("OPENMP_GPU_OFFLOAD is ${OPENMP_GPU_OFFLOAD}")
 
-if (USE_KOKKOS)
-  if (DEBUG)
+if(USE_KOKKOS)
+  if(DEBUG)
     string(APPEND CPPDEFS " -DHOMMEXX_VECTOR_SIZE=1 ")
   endif()
+
   # Generic setting that are used regardless of Architecture or Kokkos backend
   string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_DEPRECATED_CODE=OFF -DKokkos_ENABLE_EXPLICIT_INSTANTIATION=OFF")
-  if (KOKKOS_GPU_OFFLOAD)
+
+  if(KOKKOS_GPU_OFFLOAD)
     string(APPEND CPPDEFS " -DGPU -DTHRUST_IGNORE_CUB_VERSION_CHECK -DHOMMEXX_ENABLE_GPU")
     string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_AMPERE80=ON -DKokkos_ENABLE_CUDA=ON -DKokkos_ENABLE_CUDA_LAMBDA=ON -DKokkos_ENABLE_IMPL_CUDA_MALLOC_ASYNC=OFF")
     string(APPEND KOKKOS_OPTIONS " -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=OFF -DKokkos_ENABLE_AGGRESSIVE_VECTORIZATION=OFF")
@@ -27,6 +38,7 @@ if (USE_KOKKOS)
     # Enable EPYC arch in kokkos
     string(APPEND KOKKOS_OPTIONS " -DKokkos_ARCH_ZEN3=ON -DKokkos_ENABLE_SERIAL=ON -DKokkos_ENABLE_OPENMP=OFF") # work-around for nvidia as kokkos is not passing "-mp" for threaded build
   endif()
+
   string(APPEND LDFLAGS " -lstdc++ ")
   string(APPEND SLIBS " -lsci_nvidia -lkokkoscontainers -lkokkoscore -lkokkossimd ")
 endif()

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -5,17 +5,19 @@ if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
 endif()
 
-# These changes increased wallclock for a case from 170 to 4600 seconds
-# string(APPEND FFLAGS " -Minstrument")
-string(APPEND FFLAGS " -Minstrument=functions")
-
-# Add the nvhpc wrap nvtx library for instrumentation to the link step
-string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
-
 if(NOT DEBUG)
   string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
   string(APPEND CXXFLAGS " -tp=zen3")
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
+
+  # NVIDIA profiler options
+  string(APPEND FFLAGS " -Minstrument=functions")
+
+  # Add the nvhpc wrap nvtx library for instrumentation to the link step
+  string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
+
+  # Add information about optimization to the compiler output (also to the production build)
+  string(APPEND FFLAGS " -Minfo=all -Mneginfo=all")
 else()
   string(APPEND FFLAGS " -traceback")
 
@@ -23,7 +25,7 @@ else()
   string(APPEND FFLAGS " -Minfo=vect -Mneginfo=vect")
 
   # To output all information about optimization
-  # string(APPEND FFLAGS " Minfo=all -Mneginfo=all")
+  # string(APPEND FFLAGS " -Minfo=all -Mneginfo=all")
 endif()
 
 message("GPU_TYPE is ${GPU_TYPE}")

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -14,10 +14,10 @@ if(NOT DEBUG)
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
 else()
   # Add information about vectorization to the compiler output
-  string(APPEND FFLAGS " Minfo=vect and -Mneginfo=vect")
+  string(APPEND FFLAGS " Minfo=vect -Mneginfo=vect")
 
   # To output all information about optimization
-  # string(APPEND FFLAGS " Minfo=all and -Mneginfo=all")
+  # string(APPEND FFLAGS " Minfo=all -Mneginfo=all")
 endif()
 
 message("GPU_TYPE is ${GPU_TYPE}")

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -11,7 +11,7 @@ if(NOT DEBUG)
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
 
   # NVIDIA profiler options include traceback so that information on subroutine names gets to the profiler
-  string(APPEND FFLAGS " -Minstrument=functions --traceback")
+  string(APPEND FFLAGS " -Minstrument=functions -traceback")
 
   # Add the nvhpc wrap nvtx library for instrumentation to the link step
   string(APPEND LDFLAGS " -lnvhpcwrapnvtx")

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -6,7 +6,8 @@ if(COMP_NAME STREQUAL gptl)
 endif()
 
 # These changes increased wallclock for a case from 170 to 4600 seconds
-#string(APPEND FFLAGS " -Minstrument -traceback")
+# string(APPEND FFLAGS " -Minstrument")
+string(APPEND FFLAGS " -Minstrument=functions")
 
 # Add the nvhpc wrap nvtx library for instrumentation to the link step
 string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
@@ -16,6 +17,8 @@ if(NOT DEBUG)
   string(APPEND CXXFLAGS " -tp=zen3")
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
 else()
+  string(APPEND FFLAGS " -traceback")
+
   # Add information about vectorization to the compiler output
   string(APPEND FFLAGS " -Minfo=vect -Mneginfo=vect")
 

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -14,15 +14,6 @@ if(NOT DEBUG)
 
   # -Mnofma turns off Fused Multiply-Add (FMA) instructions at the link step
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
-
-  # NVIDIA profiler options include traceback so that information on subroutine names gets to the profiler
-  string(APPEND FFLAGS " -Minstrument -traceback")
-
-  # Add the nvhpc wrap nvtx library for instrumentation to the link step
-  string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
-
-  # Add information about optimization to the compiler output (also to the production build)
-  string(APPEND FFLAGS " -Minfo=all -Mneginfo=all")
 else()
   # Add debug information and symbols
   string(APPEND FFLAGS " -traceback")

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -6,12 +6,17 @@ if(COMP_NAME STREQUAL gptl)
 endif()
 
 if(NOT DEBUG)
+  # -tp is the target processor
+  # -Mstack_arrays put automatic arrays on the stack
+  # -Mallocatable=O3 use the 2003 standard for allocatable arrays, which allows them to be used in more contexts and with more features than the older Fortran 90/95 standard
   string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
   string(APPEND CXXFLAGS " -tp=zen3")
+
+  # -Mnofma turns off Fused Multiply-Add (FMA) instructions at the link step
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
 
   # NVIDIA profiler options include traceback so that information on subroutine names gets to the profiler
-  string(APPEND FFLAGS " -Minstrument=functions -traceback")
+  string(APPEND FFLAGS " -Minstrument -traceback")
 
   # Add the nvhpc wrap nvtx library for instrumentation to the link step
   string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
@@ -21,12 +26,6 @@ if(NOT DEBUG)
 else()
   # Add debug information and symbols
   string(APPEND FFLAGS " -traceback")
-
-  # Add information about vectorization to the compiler output
-  string(APPEND FFLAGS " -Minfo=vect -Mneginfo=vect")
-
-  # To output all information about optimization
-  # string(APPEND FFLAGS " -Minfo=all -Mneginfo=all")
 endif()
 
 message("GPU_TYPE is ${GPU_TYPE}")

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -7,7 +7,9 @@ endif()
 
 # These changes increased wallclock for a case from 170 to 4600 seconds
 #string(APPEND FFLAGS " -Minstrument -traceback")
-#string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
+
+# Add the nvhpc wrap nvtx library for instrumentation to the link step
+string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
 
 if(NOT DEBUG)
   string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -10,8 +10,8 @@ if(NOT DEBUG)
   string(APPEND CXXFLAGS " -tp=zen3")
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
 
-  # NVIDIA profiler options
-  string(APPEND FFLAGS " -Minstrument=functions")
+  # NVIDIA profiler options include traceback so that information on subroutine names gets to the profiler
+  string(APPEND FFLAGS " -Minstrument=functions --traceback")
 
   # Add the nvhpc wrap nvtx library for instrumentation to the link step
   string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
@@ -19,6 +19,7 @@ if(NOT DEBUG)
   # Add information about optimization to the compiler output (also to the production build)
   string(APPEND FFLAGS " -Minfo=all -Mneginfo=all")
 else()
+  # Add debug information and symbols
   string(APPEND FFLAGS " -traceback")
 
   # Add information about vectorization to the compiler output

--- a/machines/derecho/nvhpc_derecho.cmake
+++ b/machines/derecho/nvhpc_derecho.cmake
@@ -5,8 +5,9 @@ if(COMP_NAME STREQUAL gptl)
   string(APPEND CPPDEFS " -DHAVE_NANOTIME -DBIT64 -DHAVE_SLASHPROC -DHAVE_GETTIMEOFDAY")
 endif()
 
-string(APPEND FFLAGS " -Minstrument -traceback")
-string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
+# These changes increased wallclock for a case from 170 to 4600 seconds
+#string(APPEND FFLAGS " -Minstrument -traceback")
+#string(APPEND LDFLAGS " -lnvhpcwrapnvtx")
 
 if(NOT DEBUG)
   string(APPEND FFLAGS " -tp=zen3 -Mstack_arrays -Mallocatable=03")
@@ -14,7 +15,7 @@ if(NOT DEBUG)
   string(APPEND LDFLAGS " -tp=zen3 -Mnofma")
 else()
   # Add information about vectorization to the compiler output
-  string(APPEND FFLAGS " Minfo=vect -Mneginfo=vect")
+  string(APPEND FFLAGS " -Minfo=vect -Mneginfo=vect")
 
   # To output all information about optimization
   # string(APPEND FFLAGS " Minfo=all -Mneginfo=all")


### PR DESCRIPTION
Some changes mostly to the nvhpc compiler (and adding a nvhpc-prof compiler to also run profiling) for the OpenACC/NVIDIA Hackathon in late April and early May 2026.

There will probably be bits of this that we might want to bring into main development. But, it might not be clear until we are finished.

Things that likely would be good to bring in:
- [ ] Documentation of what some of the nvhpc compiler options do
- [ ] The additional nvhpc options for showing optimization
- [ ] The nvhpc-prof compiler option to run the profiler?
- [ ] Changes to optimization that we experiment with? (we'll have to verify anything here with the entire CESM, or isolate it to just CTSM code)